### PR TITLE
Updated workflow to upload Intellij Plugin

### DIFF
--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,4 +1,4 @@
-name: Run Gradle on PR
+name: Run Gradle on PR1
 on: 
   push:
   repository_dispatch:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Intellij Plugin
 on:
-  push:
+  release:
+    types: [published]
 jobs:
   trigger_workflow:
      strategy:
@@ -16,7 +17,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/myPluginRepo2
+           repository: ballerina-platform/ballerina-lang
            ref: v1.2.0
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,6 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -21,5 +20,5 @@ jobs:
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin 
-              ./gradlew publishPlugin -PintellijPublishToken=PUBLISH_TOKEN
+              ./gradlew publishPlugin -PintellijPublishToken=${{ secrets.PUBLISH_TOKEN }}
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
+         publishtoken: PUBLISH_TOKEN
      steps:
        - uses: actions/setup-java@v1
          with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,13 +8,13 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
-       - uses: actions/setup-java@v1
-         with:
-           java-version: 1.8
-       - name: use plugin repo
        - uses: actions/checkout@v2
          with:
            repository:lasinicl/myPluginRepo2
+       - uses: actions/setup-java@v1
+         with:
+           java-version: 1.8
+       - name: build gradle
          working-directory: tools-plugin/intellij
          run: ./gradlew buildPlugin
          run: ./gradlew publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK
+         
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -21,5 +21,5 @@ jobs:
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin 
-              ./gradlew publishPlugin -PintellijPublishToken=${{env.publishtoken}}
+              ./gradlew publishPlugin -PintellijPublishToken=PUBLISH_TOKEN
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -17,7 +17,7 @@ jobs:
        - uses: actions/checkout@v2
          with:
            repository: lasinicl/myPluginRepo2
-           ref: refs/tags/v1.1
+           ref: v1.2.0
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -12,6 +12,6 @@ jobs:
      steps:
        - name: dispatch intitation
          run: |
-           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches \ -H 'Accept: application/vnd.github.everest-preview+json' \ -u ${{ secrets.MY_PAT }} \ --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/.github/workflows \ -H 'Accept: application/vnd.github.everest-preview+json' \ -u ${{ secrets.MY_PAT }} \ --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
           
 

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Intellij Plugin
 on:
-  release:
-    types: [published]
+  push:
+  
 jobs:
   trigger_workflow:
      strategy:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,20 +9,12 @@ jobs:
        matrix:
          os: [ubuntu-latest, macos-latest, windows-latest]
      runs-on: ${{ matrix.os }}
-     env:
-         MY_PAT: ${{ secrets.MY_PAT }}
      steps:
-       -name: create repository dispatch event
-       if: env.REPOSITORY_DISPATCH=='true'
-       shell: pwsh
-       run: |
-          $pat = $env:MY_PAT
-          $uri = "https://github.com/lasinicl/myPluginRepo/dispatches"
-          $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f "", $pat)))
-          $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-          $headers.Add("Content-Type", "application/json")
-          $body = "{`"event_type`":`"test`",`"client_payload`":{`"unit`":false,`"integration`":true}}"
-          $response = Invoke-RestMethod -Uri $uri -Headers $headers -Body $body -Method POST
-          $response | ConvertTo-Json
+       - name: dispatch intitation
+         run: |
+           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.MY_PAT }} \
+          --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
           
 

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -7,6 +7,8 @@ jobs:
        matrix:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
+     env:
+         working-directory: ./tools-plugin/intellij
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -15,6 +17,6 @@ jobs:
          with:
            repository: lasinicl/myPluginRepo2
        - name: XXX
-         working-directory: tools-plugin/intellij
-       - run: ./gradlew buildPlugin
+         working-directory: ${{env.working-directory}}
+         run: ./gradlew buildPlugin
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -16,7 +16,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: ballerina-platform/ballerina-lang
+           repository: lasinicl/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tools-plugin/intellij
+         working-directory: ./tool-plugins/intellij
          publish_token: ${{ secrets.PUBLISH_TOKEN }}
      steps:
        - uses: actions/setup-java@v1
@@ -17,8 +17,8 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/myPluginRepo2
-           ref: dummyBranch 
+           repository: lasinicl/ballerina-lang
+           ref: master
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
+         publishToken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -20,6 +20,6 @@ jobs:
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |
-              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishtoken}}
+              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishToken}}
               ./gradlew publishPlugin
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -12,9 +12,6 @@ jobs:
      steps:
        - name: dispatch intitation
          run: |
-           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${{ secrets.MY_PAT }} \
-          --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches \ -H 'Accept: application/vnd.github.everest-preview+json' \ -u ${{ secrets.MY_PAT }} \ --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
           
 

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -20,6 +20,6 @@ jobs:
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |
-              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishtoken}}
-              ./gradlew publishPlugin
+              ./gradlew buildPlugin 
+              ./gradlew publishPlugin -PintellijPublishToken=${{env.publishtoken}}
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Intellij Plugin
 on:
-  push:
-  
+  release:
+    types: [published]
 jobs:
   trigger_workflow:
      strategy:
@@ -17,7 +17,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/ballerina-lang
+           repository: ballerina-platform/ballerina-lang
            ref: master
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -13,11 +13,11 @@ jobs:
     - uses: actions/checkout@v2
       with: 
         repository: lasinicl/myPluginRepo
-        - uses: eskatos/gradle-command-action@v1
-          with:
-             build-root-directory: /tools-plugin/intellij
-             arguments: buildPlugin
-        - uses: eskatos/gradle-command-action@v1
-          with:
-             build-root-directory: /tools-plugin/intellij
-             arguments: publishPlugin
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        build-root-directory: tools-plugin/intellij
+        arguments: buildPlugin
+    - uses: eskatos/gradle-command-action@v1
+      with:
+        build-root-directory: tools-plugin/intellij
+        arguments: publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,8 +1,6 @@
 name: Run Gradle on PR1
 on: 
-  push:
-  
-    
+  push: 
 jobs:
   trigger_workflow:
      strategy:
@@ -17,9 +15,6 @@ jobs:
        - uses: actions/checkout@v2
          with:
            repository:lasinicl/myPluginRepo2
-       - name: Build with gradle
          working-directory: tools-plugin/intellij
          run: ./gradlew buildPlugin
-       - name: Publish plugin
-         working-directory: tools-plugin/intellij
          run: ./gradlew publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -16,7 +16,7 @@ jobs:
        - uses: actions/checkout@v2
          with:
            repository: lasinicl/myPluginRepo2
-       - name: XXX
+       - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,4 +1,4 @@
-name: Run Gradle on PR
+name: Run Gradle 
 on: 
   push: 
 jobs:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -10,7 +10,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publish_token: ${{ secrets.PUBLISH_TOKEN }}
+         publish_token: ${{ secrets.IDEA_TOKEN }}
      steps:
        - uses: actions/setup-java@v1
          with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -15,6 +15,7 @@ jobs:
         repository: lasinicl/myPluginRepo
     - uses: eskatos/gradle-command-action@v1
       with:
+        wrapper-directory: tools-plugin/intellij
         arguments: buildPlugin
     - uses: eskatos/gradle-command-action@v1
       with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,4 +1,4 @@
-name: Run Gradle on PR1
+name: Run Gradle on PR
 on: 
   push: 
 jobs:
@@ -15,7 +15,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/ballerina-lang
+           repository: ballerina-platform/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,7 +8,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tools-plugin/intellij
+         working-directory: tools-plugin/intellij
      steps:
        - uses: actions/setup-java@v1
          with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,12 +8,13 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
-       - uses: actions/checkout@v2
-         with:
-           repository: lasinicl/myPluginRepo2
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8
-       - working-directory: tools-plugin/intellij
+       - uses: actions/checkout@v2
+         with:
+           repository: lasinicl/myPluginRepo2
+       - name: XXX
+         working-directory: tools-plugin/intellij
        - run: ./gradlew buildPlugin
-       - run: ./gradlew publishPlugin
+       

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,7 +1,7 @@
 name: Run Gradle on PR1
 on: 
   push:
-  repository_dispatch:
+  
     
 jobs:
   trigger_workflow:
@@ -10,12 +10,16 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
-       - uses: actions/checkout@v2
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8
-       - name: dispatch intitation
-         run: |
-           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo2/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -u ${{ secrets.MY_PAT }} --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
-          
-
+       - name: use plugin repo
+       - uses: actions/checkout@v2
+         with:
+           repository:lasinicl/myPluginRepo2
+       - name: Build with gradle
+         working-directory: tools-plugin/intellij
+         run: ./gradlew buildPlugin
+       - name: Publish plugin
+         working-directory: tools-plugin/intellij
+         run: ./gradlew publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,7 +8,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: tools-plugin/intellij
+         working-directory: /tools-plugin/intellij
      steps:
        - uses: actions/setup-java@v1
          with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publishToken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
+         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -20,6 +20,6 @@ jobs:
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |
-              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishToken}}
+              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishtoken}}
               ./gradlew publishPlugin
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
-         publishtoken: PUBLISH_TOKEN
+         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK
      steps:
        - uses: actions/setup-java@v1
          with:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -17,7 +17,7 @@ jobs:
        - uses: actions/checkout@v2
          with:
            repository: lasinicl/myPluginRepo2
-           ref: dummybranch/v1.1
+           ref: refs/tags/v1.1
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -17,7 +17,7 @@ jobs:
        - uses: actions/checkout@v2
          with:
            repository: lasinicl/myPluginRepo2
-           ref: v1.1
+           ref: dummybranch/v1.1
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,6 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
+         publishtoken: perm:bGFzaW5pLjEwMjE=.OTItMTg3MA==.JKyMl7VcyLlwaArORD9pRDgwUqVTVK 
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -19,6 +20,6 @@ jobs:
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |
-              ./gradlew buildPlugin
+              ./gradlew buildPlugin -PintellijPublishToken=${{env.publishtoken}}
               ./gradlew publishPlugin
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -7,7 +7,7 @@ jobs:
   trigger_workflow:
      strategy:
        matrix:
-         os: [ubuntu-latest,macos-latest]
+         os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tool-plugins/intellij
+         working-directory: ./tools-plugin/intellij
          publish_token: ${{ secrets.PUBLISH_TOKEN }}
      steps:
        - uses: actions/setup-java@v1
@@ -17,7 +17,8 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/ballerina-lang
+           repository: lasinicl/myPluginRepo2
+           ref: dummyBranch 
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,22 +1,28 @@
 name: Run Gradle on PR
-on: push
+on: 
+  push:
+  repository_dispatch:
+    
 jobs:
-  gradle:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - uses: actions/checkout@v2
-      with: 
-        repository: lasinicl/myPluginRepo
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        wrapper-directory: tools-plugin/intellij
-        arguments: buildPlugin
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: publishPlugin
+  trigger_workflow:
+     strategy:
+       matrix:
+         os: [ubuntu-latest, macos-latest, windows-latest]
+     runs-on: ${{ matrix.os }}
+     env:
+         MY_PAT: ${{ secrets.MY_PAT }}
+     steps:
+       -name: create repository dispatch event
+       if: env.REPOSITORY_DISPATCH=='true'
+       shell: pwsh
+       run: |
+          $pat = $env:MY_PAT
+          $uri = "https://github.com/lasinicl/myPluginRepo/dispatches"
+          $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f "", $pat)))
+          $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
+          $headers.Add("Content-Type", "application/json")
+          $body = "{`"event_type`":`"test`",`"client_payload`":{`"unit`":false,`"integration`":true}}"
+          $response = Invoke-RestMethod -Uri $uri -Headers $headers -Body $body -Method POST
+          $response | ConvertTo-Json
+          
+

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -10,7 +10,7 @@ jobs:
      steps:
        - uses: actions/checkout@v2
          with:
-           repository:lasinicl/myPluginRepo2
+           repository: lasinicl/myPluginRepo2
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -13,11 +13,9 @@ jobs:
     - uses: actions/checkout@v2
       with: 
         repository: lasinicl/myPluginRepo
-      uses: eskatos/gradle-command-action@v1
+    - uses: eskatos/gradle-command-action@v1
       with:
-        build-root-directory: tools-plugin/intellij
         arguments: buildPlugin
-      uses: eskatos/gradle-command-action@v1
+    - uses: eskatos/gradle-command-action@v1
       with:
-        build-root-directory: tools-plugin/intellij
         arguments: publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -12,6 +12,6 @@ jobs:
      steps:
        - name: dispatch intitation
          run: |
-           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -u ${{ secrets.MY_PAT }} --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo2/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -u ${{ secrets.MY_PAT }} --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
           
 

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,7 +9,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tools-plugin/intellij
+         working-directory: ./tool-plugins/intellij
          publish_token: ${{ secrets.PUBLISH_TOKEN }}
      steps:
        - uses: actions/setup-java@v1

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -7,7 +7,7 @@ jobs:
   trigger_workflow:
      strategy:
        matrix:
-         os: [ubuntu-latest, macos-latest, windows-latest]
+         os: [ubuntu-latest, macos-latest]
      runs-on: ${{ matrix.os }}
      steps:
        - name: dispatch intitation

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -14,7 +14,6 @@ jobs:
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8
-       - name: build gradle
-         working-directory: tools-plugin/intellij
-         run: ./gradlew buildPlugin
-         run: ./gradlew publishPlugin
+       - working-directory: tools-plugin/intellij
+       - run: ./gradlew buildPlugin
+       - run: ./gradlew publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,4 +1,4 @@
-name: Run Gradle 
+name: Build and Publish Intellij Plugin
 on: 
   push: 
 jobs:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -15,7 +15,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/ballerina-lang
+           repository: ballerina-platform/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -21,5 +21,5 @@ jobs:
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin 
-              ./gradlew publishPlugin -Dorg.gradle.project.intellijPublishToken=${{env.publishtoken}}
+              ./gradlew publishPlugin -PintellijPublishToken=${{env.publishtoken}}
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -10,6 +10,10 @@ jobs:
          os: [ubuntu-latest, macos-latest]
      runs-on: ${{ matrix.os }}
      steps:
+       - uses: actions/checkout@v2
+       - uses: actions/setup-java@v1
+         with:
+           java-version: 1.8
        - name: dispatch intitation
          run: |
            curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo2/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -u ${{ secrets.MY_PAT }} --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Intellij Plugin
-on: 
-  push: 
+on:
+  release:
+    types: [published]
 jobs:
   trigger_workflow:
      strategy:

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,14 +8,14 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tools-plugin/intellij
+         working-directory: ./tool-plugins/intellij
      steps:
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/myPluginRepo2
+           repository: lasinicl/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -7,7 +7,7 @@ jobs:
   trigger_workflow:
      strategy:
        matrix:
-         os: [ubuntu-latest]
+         os: [ubuntu-latest,macos-latest]
      runs-on: ${{ matrix.os }}
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -18,5 +18,7 @@ jobs:
            repository: lasinicl/myPluginRepo2
        - name: XXX
          working-directory: ${{env.working-directory}}
-         run: ./gradlew buildPlugin
+         run: |
+              ./gradlew buildPlugin
+              ./gradlew publishPlugin
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -12,6 +12,6 @@ jobs:
      steps:
        - name: dispatch intitation
          run: |
-           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/.github/workflows \ -H 'Accept: application/vnd.github.everest-preview+json' \ -u ${{ secrets.MY_PAT }} \ --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
+           curl -X POST https://api.github.com/repos/lasinicl/myPluginRepo/dispatches -H 'Accept: application/vnd.github.everest-preview+json' -u ${{ secrets.MY_PAT }} --data '{"event_type": "ping", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'" }}'
           
 

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -21,5 +21,5 @@ jobs:
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin 
-              ./gradlew publishPlugin -PintellijPublishToken=${{env.publishtoken}}
+              ./gradlew publishPlugin -Dorg.gradle.project.intellijPublishToken=${{env.publishtoken}}
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -8,14 +8,14 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: /tools-plugin/intellij
+         working-directory: ./tools-plugin/intellij
      steps:
        - uses: actions/setup-java@v1
          with:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/ballerina-lang
+           repository: lasinicl/myPluginRepo2
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -7,7 +7,7 @@ jobs:
   trigger_workflow:
      strategy:
        matrix:
-         os: [ubuntu-latest, macos-latest]
+         os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      steps:
        - uses: actions/checkout@v2

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -9,6 +9,7 @@ jobs:
      runs-on: ${{ matrix.os }}
      env:
          working-directory: ./tool-plugins/intellij
+         publish_token: ${{ secrets.PUBLISH_TOKEN }}
      steps:
        - uses: actions/setup-java@v1
          with:
@@ -20,5 +21,5 @@ jobs:
          working-directory: ${{env.working-directory}}
          run: |
               ./gradlew buildPlugin 
-              ./gradlew publishPlugin -PintellijPublishToken=${{ secrets.PUBLISH_TOKEN }}
+              ./gradlew publishPlugin -PintellijPublishToken=${{ env.publish_token }}
        

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -1,7 +1,6 @@
 name: Build and Publish Intellij Plugin
 on:
-  release:
-    types: [published]
+  push:
 jobs:
   trigger_workflow:
      strategy:
@@ -9,7 +8,7 @@ jobs:
          os: [ubuntu-latest]
      runs-on: ${{ matrix.os }}
      env:
-         working-directory: ./tool-plugins/intellij
+         working-directory: ./tools-plugin/intellij
          publish_token: ${{ secrets.PUBLISH_TOKEN }}
      steps:
        - uses: actions/setup-java@v1
@@ -17,8 +16,8 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: ballerina-platform/ballerina-lang
-           ref: master
+           repository: lasinicl/myPluginRepo2
+           ref: v1.1
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -15,7 +15,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: lasinicl/myPluginRepo2
+           repository: lasinicl/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -13,11 +13,11 @@ jobs:
     - uses: actions/checkout@v2
       with: 
         repository: lasinicl/myPluginRepo
-    - uses: eskatos/gradle-command-action@v1
+      uses: eskatos/gradle-command-action@v1
       with:
         build-root-directory: tools-plugin/intellij
         arguments: buildPlugin
-    - uses: eskatos/gradle-command-action@v1
+      uses: eskatos/gradle-command-action@v1
       with:
         build-root-directory: tools-plugin/intellij
         arguments: publishPlugin

--- a/.github/workflows/intellijPluginUpload.yml
+++ b/.github/workflows/intellijPluginUpload.yml
@@ -15,7 +15,7 @@ jobs:
            java-version: 1.8
        - uses: actions/checkout@v2
          with:
-           repository: ballerina-platform/ballerina-lang
+           repository: lasinicl/ballerina-lang
        - name: build and publish plugin
          working-directory: ${{env.working-directory}}
          run: |


### PR DESCRIPTION
use "ref:" to add the required branch or tag to checkout
IntelliJ publish token should be added as a secret. 