### PR TITLE
Add Workflow for Homebrew Publishing

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -8,12 +8,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Check out repository.
+      uses: actions/checkout@v2
 
     - name: Set up Python 3.x
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
         
     - name: wget required files
       run: wget -O ./publish_scripts/latest_release.json https://product-dist.ballerina.io/downloads/latest_release.json?982
@@ -34,5 +35,5 @@ jobs:
           exit 1
         fi
 
-        python3 ./publish_scripts/homebrew_publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
+        python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
       

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Send the PR to Homebrew
         run: |
           python -m pip install --upgrade pip
-          pip insatll PyGithub
+          pip install PyGithub
           version=$(cat ./publish_scripts/latest_release.json | jq '.version')
           version=$(sed -e 's/^"//' -e 's/"$//' <<<"$version")
           

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -1,0 +1,38 @@
+# Github action to open a PR in Homebrew/homebrew-core when a new release of ballerina is being published
+name: Update Homebrew
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+        
+    - name: wget required files
+      run: wget -O ./publish_scripts/latest_release.json https://product-dist.ballerina.io/downloads/latest_release.json?982
+    
+    - name: Send the PR to Homebrew
+      run: |
+        python -m pip install --upgrade pip
+        pip insatll PyGithub
+        version=$(cat ./publish_scripts/latest_release.json | jq '.version')
+        version=$(sed -e 's/^"//' -e 's/"$//' <<<"$version")
+        
+        dist_url="https://product-dist.ballerina.io/downloads/$version/ballerina-$version.zip"
+        
+        checksum="$(curl -fsSL "$dist_url" | shasum -a 256 -b | awk '{print $1}')"
+
+        if [ -z "$checksum" ]; then
+          echo "ERROR: calculating the checksum failed for $url" >&2
+          exit 1
+        fi
+
+        python3 ./publish_scripts/homebrew_publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
+      

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -32,7 +32,7 @@ jobs:
           checksum="$(curl -fsSL "$dist_url" | shasum -a 256 -b | awk '{print $1}')"
 
           if [ -z "$checksum" ]; then
-            echo "ERROR: calculating the checksum failed for $url" >&2
+            echo "ERROR: calculating the checksum failed for $dist_url" >&2
             exit 1
           fi
 

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -36,5 +36,5 @@ jobs:
             exit 1
           fi
 
-          python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$dist_url"
+          python3 ./publish_scripts/homebrew-publish.py ${{ secrets.WEBSITE_TOKEN }} "$version" "$checksum" "$dist_url"
       

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -8,32 +8,33 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out repository.
-      uses: actions/checkout@v2
-
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
+      - name: Check out repository.
+        uses: actions/checkout@v2
+      
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
         
-    - name: wget required files
-      run: wget -O ./publish_scripts/latest_release.json https://product-dist.ballerina.io/downloads/latest_release.json?982
-    
-    - name: Send the PR to Homebrew
-      run: |
-        python -m pip install --upgrade pip
-        pip insatll PyGithub
-        version=$(cat ./publish_scripts/latest_release.json | jq '.version')
-        version=$(sed -e 's/^"//' -e 's/"$//' <<<"$version")
+      - name: Wget required files
+        id: version
+        run: wget -O ./publish_scripts/latest_release.json https://product-dist.ballerina.io/downloads/latest_release.json?982
         
-        dist_url="https://product-dist.ballerina.io/downloads/$version/ballerina-$version.zip"
-        
-        checksum="$(curl -fsSL "$dist_url" | shasum -a 256 -b | awk '{print $1}')"
+      - name: Send the PR to Homebrew
+        run: |
+          python -m pip install --upgrade pip
+          pip insatll PyGithub
+          version=$(cat ./publish_scripts/latest_release.json | jq '.version')
+          version=$(sed -e 's/^"//' -e 's/"$//' <<<"$version")
+          
+          dist_url="https://product-dist.ballerina.io/downloads/$version/ballerina-$version.zip"
+          
+          checksum="$(curl -fsSL "$dist_url" | shasum -a 256 -b | awk '{print $1}')"
 
-        if [ -z "$checksum" ]; then
-          echo "ERROR: calculating the checksum failed for $url" >&2
-          exit 1
-        fi
+          if [ -z "$checksum" ]; then
+            echo "ERROR: calculating the checksum failed for $url" >&2
+            exit 1
+          fi
 
-        python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
+          python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
       

--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -36,5 +36,5 @@ jobs:
             exit 1
           fi
 
-          python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$zip_url"
+          python3 ./publish_scripts/homebrew-publish.py ${{ secrets.ACCESS_TOKEN }} "$version" "$checksum" "$dist_url"
       

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -1,0 +1,60 @@
+import sys
+from github import Github
+
+# Getting the command line arguments as inputs
+token = sys.argv[1]
+version = sys.argv[2]
+sha256 = sys.argv[3]
+url = sys.argv[4]
+
+sha256_replacement = '  sha256 "'+sha256+'"\n'
+
+url_replacement = '  url "'+url+'"\n'
+
+updated_ballerina_rb = ""
+
+# Getting an instance of the Homebrew/homebrew-core repo
+homebrew_user = g.get_user("Homebrew")
+homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
+
+# Reading the current ballerina.rb Formula file and updating it.
+ballerina_rb_file = homebrew_core_repo.get_contents("Formula/ballerina.rb")
+
+for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
+    updated_line = line
+    if(line.startswith('  url "')):
+        updated_line = url_replacement
+    elif(line.startswith('  sha256 "')):
+        updated_line = sha256_replacement
+
+    updated_ballerina_rb += updated_line
+
+            
+
+commit_msg = "ballerina "+str(version)
+
+
+g = Github(token)
+
+current_user = g.get_user()
+current_user_login = current_user.login
+
+# Commiting and pushing the updated ballerina.rb file to the current users forked homebrew-core repo
+# [Important]The user who provides the access token also should fork the Homebrew/homebrew-core repo in order for this to work
+
+repo = g.get_repo(current_user_login+"/homebrew-core")
+contents = repo.get_contents("Formula/ballerina.rb", ref="master")
+update = repo.update_file(contents.path, commit_msg, updated_ballerina_rb, contents.sha, branch="master")
+
+
+# Opening a PR in Homebrew/homebrew-core repo
+
+body = '''
+ - [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
+ - [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
+ - [x] Have you built your formula locally with ```brew install --build-from-source <formula>```, where ```<formula>``` is the name of the formula you're submitting?
+ - [x] Is your test running fine ```brew test <formula>```, where ```<formula>``` is the name of the formula you're submitting?
+ - [x] Does your build pass ```brew audit --strict <formula>``` (after doing ```brew install <formula>```)?
+'''
+
+pr = homebrew_core_repo.create_pull(title=commit_msg, body=body, base="master", head='{}:{}'.format(current_user_login, 'master'))

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -13,6 +13,8 @@ url_replacement = '  url "'+url+'"\n'
 
 updated_ballerina_rb = ""
 
+g = Github(token)
+
 # Getting an instance of the Homebrew/homebrew-core repo
 homebrew_user = g.get_user("iHomebrew")
 homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
@@ -33,8 +35,6 @@ for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
 
 commit_msg = "ballerina "+str(version)
 
-
-g = Github(token)
 
 current_user = g.get_user()
 current_user_login = current_user.login

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -32,7 +32,7 @@ for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
 
     updated_ballerina_rb += updated_line+"\n"
 
-            
+updated_ballerina_rb = updated_ballerina_rb[:-1]
 
 commit_msg = "ballerina "+str(version)
 

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -29,7 +29,7 @@ for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
     elif(line.startswith('  sha256 "')):
         updated_line = sha256_replacement
 
-    updated_ballerina_rb += updated_line
+    updated_ballerina_rb += updated_line+"\n"
 
             
 

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -16,7 +16,7 @@ updated_ballerina_rb = ""
 g = Github(token)
 
 # Getting an instance of the Homebrew/homebrew-core repo
-homebrew_user = g.get_user("iHomebrew")
+homebrew_user = g.get_user("Homebrew")
 homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
 
 # Reading the current ballerina.rb Formula file and updating it.

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -16,7 +16,8 @@ updated_ballerina_rb = ""
 g = Github(token)
 
 # Getting an instance of the Homebrew/homebrew-core repo
-homebrew_user = g.get_user("Homebrew")
+#TODO: Change this to homebrew_user = g.get_user("Homebrew") in production usage
+homebrew_user = g.get_user("s-anjana")
 homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
 
 # Reading the current ballerina.rb Formula file and updating it.

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -14,7 +14,7 @@ url_replacement = '  url "'+url+'"\n'
 updated_ballerina_rb = ""
 
 # Getting an instance of the Homebrew/homebrew-core repo
-homebrew_user = g.get_user("Homebrew")
+homebrew_user = g.get_user("iHomebrew")
 homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
 
 # Reading the current ballerina.rb Formula file and updating it.

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -16,7 +16,7 @@ updated_ballerina_rb = ""
 g = Github(token)
 
 # Getting an instance of the Homebrew/homebrew-core repo
-homebrew_user = g.get_user("Homebrew")
+homebrew_user = g.get_user("iHomebrew")
 homebrew_core_repo = homebrew_user.get_repo("homebrew-core")
 
 # Reading the current ballerina.rb Formula file and updating it.

--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -32,7 +32,7 @@ for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
 
     updated_ballerina_rb += updated_line+"\n"
 
-updated_ballerina_rb = updated_ballerina_rb[:-1]
+updated_ballerina_rb = updated_ballerina_rb.rstrip()
 
 commit_msg = "ballerina "+str(version)
 


### PR DESCRIPTION
## Purpose
> The workflow and the python script added here would be creating a PR to Homebrew/homebrew-core at each new release.

## Approach
> The latest version of the ballerina release is captured and the homebrew-core/Formula/ballerina.rb file is updated using a script. A PR would be opened in the Homebrew/homebrew-core repo using the Python Github API library.

## Documentation
> There should be a ACCESS_TOKEN variable with public_repo access privileges set in the secrets section of a user who already has forked the [Homebrew/homebrew-core repo](https://github.com/Homebrew/homebrew-core)