### PR TITLE
homebrew-publish: Remove superfluous newlines in sha256 and url

### DIFF
--- a/publish_scripts/homebrew-publish.py
+++ b/publish_scripts/homebrew-publish.py
@@ -7,9 +7,9 @@ version = sys.argv[2]
 sha256 = sys.argv[3]
 url = sys.argv[4]
 
-sha256_replacement = '  sha256 "'+sha256+'"\n'
+sha256_replacement = '  sha256 "'+sha256+'"'
 
-url_replacement = '  url "'+url+'"\n'
+url_replacement = '  url "'+url+'"'
 
 updated_ballerina_rb = ""
 


### PR DESCRIPTION
## Purpose

Remove superfluous new lines to fix not-to-style Homebrew formula bump script so that it matches Homebrew's preferred style.

## Goals

Less to do for Homebrew maintainers when receiving one of your bot's PRs.

## Approach

N/A

## User stories

N/A

## Release note

Fix Homebrew publishing script to adhere to Homebrew's preferred style.

## Documentation

N/A

## Training

N/A

## Certification

N/A - automatic release process tweak

## Marketing

N/A

## Automation tests

N/A

## Security checks

 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? n/a
 - Ran FindSecurityBugs plugin and verified report? n/a
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

-----

- Hey, I'm from the Homebrew team. We got @ballerina-bot's [first PR](https://github.com/Homebrew/homebrew-core/pull/54056) to update the Ballerina version. It had some style errors.
- This attempts to fix these for the future: we don't need newlines between the URL and SHA256.
- It may also be worth pushing to a branch other than `master`, say `ballerina-<version>`, but that's for your project to decide so I haven't made that change here!
- Also, if you don't fancy maintaining this script long-term, there's a [GitHub Action](https://github.com/marketplace/actions/bump-homebrew-formula) that can run `brew bump-formula-pr` when releases are tagged in your repos.

Before:

```
class Ballerina < Formula
  desc "Programming Language for Network Distributed Applications"
  homepage "https://ballerina.io"
  url "https://product-dist.ballerina.io/downloads/1.2.3/ballerina-1.2.3.zip"

  sha256 "0b19b1905bef8e5233099c3bce9af68c8ade28611637889928dfeda52acd3ea6"

```

After:

```
class Ballerina < Formula
  desc "Programming Language for Network Distributed Applications"
  homepage "https://ballerina.io"
  url "https://product-dist.ballerina.io/downloads/1.2.3/ballerina-1.2.3.zip"
  sha256 "0b19b1905bef8e5233099c3bce9af68c8ade28611637889928dfeda52acd3ea6"
```