### PR TITLE
Add standard library content to the release note

### DIFF
--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -184,8 +184,8 @@ Introduced module error inheritance and remove error union types.
 
 ##### WebSocket Package Updates
 
-Introduced auth support for the websocket client.
-Bearer token, Basic auth, JWT, and OAuth2 support has been introduced with the WebSocket client declarative authentication.
+Introduced auth support for the WebSocket client.
+The bearer token, Basic Auth, JWT, and OAuth2 support have been introduced with the WebSocket client declarative authentication.
 
 Introduced HTTP cookie support for the WebSocket client.
 ```ballerina
@@ -202,7 +202,7 @@ websocket:Client wsClient = check new ("ws://localhost:21316/ws", config = clien
 Made the `websocket:Caller` optional in WebSocket service remote functions.
 
 Introduced support to send text, binary, and pong messages by returning them from the remote methods. 
-Users can send text/binary data to the peer by returning a `string` or a `byte[]` value from the `onTextMessage` and `onBinaryMessage` remote methods. And users can send a pong frame to the peer by returning a `byte[]` value from the `onPing` remote method.
+Text/binary data can now be sent to the peer by returning a `string` or a `byte[]` value from the `onTextMessage` and `onBinaryMessage` remote methods. Also, a pong frame can be sent to the peer by returning a `byte[]` value from the `onPing` remote method.
 ```ballerina
 remote function onTextMessage(string text) returns string {
     return "Hello World!";
@@ -214,7 +214,7 @@ remote function onPing(byte[] pingData) returns byte[] {
 }
 ```
 
-Removed the support for `websocket:AsyncClient`.
+Removed the support for the `websocket:AsyncClient`.
 
 ##### GraphQL Package Updates
 
@@ -253,7 +253,7 @@ resource function get profile/name/first(int id) returns string? {
 
 Enabled read/listen for multiple emails in a single TCP connection.
 Each POP3 or IMAP client/listener creation initiates the connection.
-Then email sending, receiving or listening operation can be performed many times.
+Then, the email sending, receiving, or listening operations can be performed many times.
 Finally the client/listener has to be closed.
 
 POP3 Client example
@@ -263,7 +263,7 @@ email:Message? emailResponse = check popClient->receiveMessage();
 check popClient->close();
 ```
 
-In IMAP Client a similar format is used.
+A similar format is used in the IMAP client. 
 
 POP3 Service example
 ```ballerina
@@ -290,26 +290,26 @@ Made email body a mandatory field in `sendEmail` method API.
 Renamed email sending method names removing `Email` in each of them 
 Renamed `sendEmail` as `send`, `sendEmailMessage` as `sendMessage`, `receiveEmailMessage` as `receiveMessage` and `onEmailMessage` as `onMessage`.
 
-Set default `from` address of `email:Message` record from the `SmtpClient` authentication field, `username`.
-Earlier the username for authentication was decoupled from message data. Now the field `from` is made optional and default value will be set from the username.
+Set the default `from` address of the `email:Message` record from the `SmtpClient` authentication field, `username`.
+Earlier, the username for authentication was decoupled from the message data. Now, the `from` field is made optional and the default value will be set from the username.
 
-Made POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument
-Time unit is seconds and the data type is `decimal`. Default value is 0 where the inbuilt polling interval is 100 milliseconds.
+Made POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument.
+The time unit is in seconds and the data type is `decimal`. The default value is 0 in which the inbuilt polling interval is 100 milliseconds.
 A sample client code is as follows.
 ```ballerina
 email:Message|email:Error? email = popClient->receiveMessage(timeout = 2);
 ```
-In `PopListener` and `ImapListener` configuration polling interval is not set with `decimal` type in seconds to the field, `pollingInterval`, which was earlier named as `pollingIntervalInMillis`.
+In the `PopListener` and `ImapListener` configurations, the polling interval is not set with the  `decimal` type in seconds to the `pollingInterval` field, which was earlier named as `pollingIntervalInMillis`.
 
-Renamed `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig` and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration` and `email:ImapListenerConfiguration` respectively.
+Renamed the `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig`, and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration`, and `email:ImapListenerConfiguration` respectively.
 
-Removed the field, `cronExpression` from `email:ImapListenerConfig` and `email:PopListenerConfig`.
+Removed the `cronExpression` field from the `email:ImapListenerConfig` and `email:PopListenerConfig`.
 
-Made the `body` field of `send` method mandatory in `email:SmtpClient`. 
+Made the `body` field of the `send` method mandatory in the `email:SmtpClient`. 
 
 ##### WebSub Package Updates
 
-Introduced websub-listener-configuration for websub-listener
+Introduced a websub-listener configuration for the websub-listener.
 ```ballerina
 import ballerina/websub;
 
@@ -330,7 +330,7 @@ service /subscriber on new websub:Listener(9090, configs) {
 
 ##### WebSubHub Package Updates
 
-Included HTTP Headers parameter into WebSub Hub API
+Included HTTP Headers parameter into the WebSub Hub API.
 ```ballerina
 import ballerina/websubhub;
 import ballerina/http;
@@ -346,7 +346,7 @@ service /websubhub on new websubhub:Listener(9090) {
 }
 ```
 
-Introduced pre-initialized constant responses to be used in `websubhub:Service` implementation
+Introduced pre-initialized constant responses to be used in the `websubhub:Service` implementation.
 ```ballerina
 import ballerina/websubhub;
 
@@ -362,7 +362,7 @@ service /websubhub on new websubhub:Listener(9090) {
 }
 ```
 
-Initializing `websubhub:HubClient` with client configurations
+Initializing the `websubhub:HubClient` with the client configurations.
 ```ballerina
 import ballerina/websubhub;
 
@@ -384,7 +384,7 @@ websubhub:ContentDistributionMessage msg = {content: "This is sample content del
 var publishResponse = hubClientEP->notifyContentDistribution(msg);
 ```
 
-Introduced websubhub listener configuration to configure websubhub listener. 
+Introduced an websubhub-listener configuration to configure a websubhub listener. 
 ```ballerina
 import ballerina/websubhub;
 
@@ -414,7 +414,7 @@ string|url:Error encoded = url:encode("http://localhost:9090", "UTF-8");
 string|url:Error decoded = url:decode("http%3A%2F%2Flocalhost%3A9090", "UTF-8");
 ```
 
-The Ballerina HTTP listener can be configured to authenticate and authorize the inbound requests with Basic Auth file user store.
+The Ballerina HTTP listener can be configured to authenticate and authorize the inbound requests with a Basic Auth file user store.
 
 Improved client and listener `SecureSocket` APIs of HTTP, GRPC, WebSocket, GraphQL, WebSub, WebSubHub, TCP, Email, NATS, STAN and RabbitMQ modules.
 ```ballerina
@@ -482,9 +482,9 @@ public enum CertValidationType {
 }
 ```
 
-Improved `SecureSocket` configuration of JDK11 client of JWT and OAuth2 modules.
+Improved the `SecureSocket` configuration of the JDK11 client of the JWT and OAuth2 modules.
 
-Added support for OAuth2 client authentication of JDK11 client, which is used to call authorization endpoint.
+Added support for OAuth2 client authentication of the JDK11 client, which is used to call an authorization endpoint.
 
 ##### TCP Package Updates
 
@@ -545,7 +545,7 @@ service class EchoService {
 }
 ```
 
-Included tcp:Caller as an optional parameter in onBytes() method.
+Included a `tcp:Caller` as an optional parameter in the `onBytes()` method.
 ```
 service class EchoService {
   
@@ -558,31 +558,31 @@ service class EchoService {
 
 ##### Kafka Package Updates
 
-Renamed `sendProducerRecord` function in the client object `Producer` to `send`.
+Renamed the `sendProducerRecord` function in the client object `Producer` to `send`.
 
-Renamed `flushRecords` function in the client object `Producer` to `’flush`.
+Renamed the `flushRecords` function in the client object `Producer` to `’flush`.
 
-Replaced `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
+Replaced the `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
 
 ##### NATS Package Updates
 
-Renamed `ConnectionConfig` record to `ConnectionConfiguration`. 
+Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
 
-Included `url` as a field in `ConnectionConfiguration` record. 
+Included `url` as a field in the `ConnectionConfiguration` record. 
 
-Changed `ConnectionConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
+Changed the `ConnectionConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
 
 ##### STAN Package Updates
 
-Renamed `StreamingConfig` record to `StreamingConfiguration`. 
+Renamed the `StreamingConfig` record to `StreamingConfiguration`. 
 
-Included `url` as a field in `StreamingConfiguration` record. 
+Included the `url` as a field in the `StreamingConfiguration` record. 
 
-Changed `StreamingConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
+Changed the `StreamingConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
 
 ##### RabbitMQ Package Updates
 
-Renamed `ConnectionConfig` record to `ConnectionConfiguration`. 
+Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
 
 ###### Common Standard Library Updates
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -146,7 +146,7 @@ io:println(nameText); // "DanBrown"
 
 ##### HTTP Package Updates
 
-Changed the return types of the client methods to depend on the `targetType` argument. The default `targetType` is `http:Response`.
+###### Changed the return types of the client methods to depend on the `targetType` argument. The default `targetType` is `http:Response`.
 ```ballerina 
 http:Client myClient = check new ("http://localhost:9090”);
 http:Response response = check myClient->post("/backend/getResponse", "want response");
@@ -154,14 +154,14 @@ json jsonPayload = check myClient->post("/backend/getJson", "want json", targetT
 xml xmlPayload = check myClient->post("/backend/getXml", "want xml", targetType = xml);
 ```
 
-Introduced a header map as an optional argument for non-entity-body client remote methods (GET, HEAD, OPTIONS). 
+###### Introduced a header map as an optional argument for non-entity-body client remote methods (GET, HEAD, OPTIONS). 
 ```ballerina
 http:Client myClient = check new ("http://localhost:9090”);
 map<string|string[]> accHeaders = { "Accept" : "application/json" };
 var response = myclient->get("/some/endpoint", accHeaders);
 ```
 
-Introduced header map and media type as optional arguments for entity body client remote methods (POST, PUT, PATCH, DELETE, EXECUTE).
+###### Introduced header map and media type as optional arguments for entity body client remote methods (POST, PUT, PATCH, DELETE, EXECUTE).
 ```ballerina
 http:Client myClient = check new ("http://localhost:9090”);
 json payload = {}; 
@@ -169,7 +169,7 @@ map<string|string[]> accHeaders = { "Accept" : "application/json" };
 var response = myclient->post("/some/endpoint", payload, headers = accHeaders);
 ```
 
-Improved the data types of outbound request/response payloads which can be set directly.  
+###### Improved the data types of outbound request/response payloads which can be set directly.  
 ```ballerina
 type RequestMessage Request|string|xml|json[]|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
                       table<map<json>>[]|mime:Entity[]|stream<byte[], io:Error>|();
@@ -178,9 +178,9 @@ type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|m
                       (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error>|();
 ```
 
-Marked HTTP client remote methods as isolated.
+###### Marked HTTP client remote methods as isolated.
 
-Introduced module error inheritance and remove error union types.
+###### Introduced module error inheritance and remove error union types.
 
 ##### WebSocket Package Updates
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -184,10 +184,10 @@ type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|m
 
 ##### WebSocket Package Updates
 
-Introduced auth support for the WebSocket client.
+###### Introduced auth support for the WebSocket client.
 The bearer token, Basic Auth, JWT, and OAuth2 support have been introduced with the WebSocket client declarative authentication.
 
-Introduced HTTP cookie support for the WebSocket client.
+###### Introduced HTTP cookie support for the WebSocket client.
 ```ballerina
 http:Cookie cookie = new ("username", "name");
 http:Cookie[] httpCookies = [cookie];
@@ -199,9 +199,9 @@ websocket:ClientConfiguration clientConf = {
 websocket:Client wsClient = check new ("ws://localhost:21316/ws", config = clientConf);
 ```
 
-Made the `websocket:Caller` optional in WebSocket service remote functions.
+###### Made the `websocket:Caller` optional in WebSocket service remote functions.
 
-Introduced support to send text, binary, and pong messages by returning them from the remote methods. 
+###### Introduced support to send text, binary, and pong messages by returning them from the remote methods. 
 Text/binary data can now be sent to the peer by returning a `string` or a `byte[]` value from the `onTextMessage` and `onBinaryMessage` remote methods. Also, a pong frame can be sent to the peer by returning a `byte[]` value from the `onPing` remote method.
 ```ballerina
 remote function onTextMessage(string text) returns string {
@@ -214,11 +214,11 @@ remote function onPing(byte[] pingData) returns byte[] {
 }
 ```
 
-Removed the support for the `websocket:AsyncClient`.
+###### Removed the support for the `websocket:AsyncClient`.
 
 ##### GraphQL Package Updates
 
-Added the support for hierarchical resource paths.
+###### Added the support for hierarchical resource paths.
 The Ballerina GraphQL resources now can have hierarchical resource paths. Each intermediate resource path then maps to a new type in the generated schema.
 ```ballerina
 import ballerina/graphql;
@@ -238,7 +238,7 @@ service /graphql on new Listener(9104) {
 }
 ```
 
-Supported resource functions to return optional types. 
+###### Supported resource functions to return optional types. 
 
 The Ballerina GraphQL resources now can return optional types. 
 ```ballerina
@@ -251,7 +251,7 @@ resource function get profile/name/first(int id) returns string? {
 
 ##### Email Package Updates
 
-Enabled read/listen for multiple emails in a single TCP connection.
+###### Enabled read/listen for multiple emails in a single TCP connection.
 Each POP3 or IMAP client/listener creation initiates the connection.
 Then, the email sending, receiving, or listening operations can be performed many times.
 Finally the client/listener has to be closed.
@@ -285,31 +285,31 @@ service object {} emailObserver = service object {
 
 Note how the `close()` method calls the `onClose` method in the service.
 
-Made email body a mandatory field in `sendEmail` method API.
+###### Made email body a mandatory field in `sendEmail` method API.
 
-Renamed email sending method names removing `Email` in each of them 
+###### Renamed email sending method names removing `Email` in each of them 
 Renamed `sendEmail` as `send`, `sendEmailMessage` as `sendMessage`, `receiveEmailMessage` as `receiveMessage` and `onEmailMessage` as `onMessage`.
 
-Set the default `from` address of the `email:Message` record from the `SmtpClient` authentication field, `username`.
+###### Set the default `from` address of the `email:Message` record from the `SmtpClient` authentication field, `username`.
 Earlier, the username for authentication was decoupled from the message data. Now, the `from` field is made optional and the default value will be set from the username.
 
-Made POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument.
+###### Made POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument.
 The time unit is in seconds and the data type is `decimal`. The default value is 0 in which the inbuilt polling interval is 100 milliseconds.
 A sample client code is as follows.
 ```ballerina
 email:Message|email:Error? email = popClient->receiveMessage(timeout = 2);
 ```
-In the `PopListener` and `ImapListener` configurations, the polling interval is not set with the  `decimal` type in seconds to the `pollingInterval` field, which was earlier named as `pollingIntervalInMillis`.
+###### In the `PopListener` and `ImapListener` configurations, the polling interval is not set with the  `decimal` type in seconds to the `pollingInterval` field, which was earlier named as `pollingIntervalInMillis`.
 
-Renamed the `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig`, and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration`, and `email:ImapListenerConfiguration` respectively.
+###### Renamed the `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig`, and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration`, and `email:ImapListenerConfiguration` respectively.
 
-Removed the `cronExpression` field from the `email:ImapListenerConfig` and `email:PopListenerConfig`.
+###### Removed the `cronExpression` field from the `email:ImapListenerConfig` and `email:PopListenerConfig`.
 
-Made the `body` field of the `send` method mandatory in the `email:SmtpClient`. 
+###### Made the `body` field of the `send` method mandatory in the `email:SmtpClient`. 
 
 ##### WebSub Package Updates
 
-Introduced a websub-listener configuration for the websub-listener.
+###### Introduced a websub-listener configuration for the websub-listener.
 ```ballerina
 import ballerina/websub;
 
@@ -330,7 +330,7 @@ service /subscriber on new websub:Listener(9090, configs) {
 
 ##### WebSubHub Package Updates
 
-Included HTTP Headers parameter into the WebSub Hub API.
+###### Included HTTP Headers parameter into the WebSub Hub API.
 ```ballerina
 import ballerina/websubhub;
 import ballerina/http;
@@ -346,7 +346,7 @@ service /websubhub on new websubhub:Listener(9090) {
 }
 ```
 
-Introduced pre-initialized constant responses to be used in the `websubhub:Service` implementation.
+###### Introduced pre-initialized constant responses to be used in the `websubhub:Service` implementation.
 ```ballerina
 import ballerina/websubhub;
 
@@ -384,7 +384,7 @@ websubhub:ContentDistributionMessage msg = {content: "This is sample content del
 var publishResponse = hubClientEP->notifyContentDistribution(msg);
 ```
 
-Introduced an websubhub-listener configuration to configure a websubhub listener. 
+###### Introduced an websubhub-listener configuration to configure a websubhub listener. 
 ```ballerina
 import ballerina/websubhub;
 
@@ -406,7 +406,7 @@ service /hub on new websubhub:Listener(9090, configs) {
 
 ##### Security Updates
 
-Renamed the `ballerina/encoding` module as `ballerina/url` and updated the APIs.
+###### Renamed the `ballerina/encoding` module as `ballerina/url` and updated the APIs.
 ```ballerina
 import ballerina/url;
 
@@ -414,9 +414,9 @@ string|url:Error encoded = url:encode("http://localhost:9090", "UTF-8");
 string|url:Error decoded = url:decode("http%3A%2F%2Flocalhost%3A9090", "UTF-8");
 ```
 
-The Ballerina HTTP listener can be configured to authenticate and authorize the inbound requests with a Basic Auth file user store.
+###### The Ballerina HTTP listener can be configured to authenticate and authorize the inbound requests with a Basic Auth file user store.
 
-Improved client and listener `SecureSocket` APIs of HTTP, GRPC, WebSocket, GraphQL, WebSub, WebSubHub, TCP, Email, NATS, STAN and RabbitMQ modules.
+###### Improved client and listener `SecureSocket` APIs of HTTP, GRPC, WebSocket, GraphQL, WebSub, WebSubHub, TCP, Email, NATS, STAN and RabbitMQ modules.
 ```ballerina
 public type ListenerSecureSocket record {|
    crypto:KeyStore|CertKey key;
@@ -482,13 +482,13 @@ public enum CertValidationType {
 }
 ```
 
-Improved the `SecureSocket` configuration of the JDK11 client of the JWT and OAuth2 modules.
+###### Improved the `SecureSocket` configuration of the JDK11 client of the JWT and OAuth2 modules.
 
-Added support for OAuth2 client authentication of the JDK11 client, which is used to call an authorization endpoint.
+###### Added support for OAuth2 client authentication of the JDK11 client, which is used to call an authorization endpoint.
 
 ##### TCP Package Updates
 
-Introduced SSL/TLS support for both the client and listener.
+###### Introduced SSL/TLS support for both the client and listener.
 ```ballerina
 import ballerina/tcp;
 
@@ -545,7 +545,7 @@ service class EchoService {
 }
 ```
 
-Included a `tcp:Caller` as an optional parameter in the `onBytes()` method.
+###### Included a `tcp:Caller` as an optional parameter in the `onBytes()` method.
 ```
 service class EchoService {
   
@@ -558,35 +558,35 @@ service class EchoService {
 
 ##### Kafka Package Updates
 
-Renamed the `sendProducerRecord` function in the client object `Producer` to `send`.
+###### Renamed the `sendProducerRecord` function in the client object `Producer` to `send`.
 
-Renamed the `flushRecords` function in the client object `Producer` to `’flush`.
+###### Renamed the `flushRecords` function in the client object `Producer` to `’flush`.
 
-Replaced the `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
+###### Replaced the `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
 
 ##### NATS Package Updates
 
-Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
+###### Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
 
-Included `url` as a field in the `ConnectionConfiguration` record. 
+###### Included `url` as a field in the `ConnectionConfiguration` record. 
 
-Changed the `ConnectionConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
+###### Changed the `ConnectionConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
 
 ##### STAN Package Updates
 
-Renamed the `StreamingConfig` record to `StreamingConfiguration`. 
+###### Renamed the `StreamingConfig` record to `StreamingConfiguration`. 
 
-Included the `url` as a field in the `StreamingConfiguration` record. 
+###### Included the `url` as a field in the `StreamingConfiguration` record. 
 
-Changed the `StreamingConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
+###### Changed the `StreamingConfiguration` in the client and listener init functions to an included record parameter. This allows the record field values to be passed as named parameters. 
 
 ##### RabbitMQ Package Updates
 
-Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
+###### Renamed the `ConnectionConfig` record to `ConnectionConfiguration`. 
 
 ###### Common Standard Library Updates
 
-All the timeout configurations are converted to accept decimal values and the time unit is in seconds.
+###### All the timeout configurations are converted to accept decimal values and the time unit is in seconds.
 
 #### Code to Cloud
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -161,7 +161,7 @@ map<string|string[]> accHeaders = {};
 var response = myclient->get("/some/endpoint", accHeaders);
 ```
 
-Introduce header map and media type as optional arguments for entity body client remote methods (POST, PUT, PATCH, DELETE, EXECUTE).
+Introduced header map and media type as optional arguments for entity body client remote methods (POST, PUT, PATCH, DELETE, EXECUTE).
 ```ballerina
 http:Client myClient = check new ("http://localhost:9090”);
 json payload = {}; 
@@ -169,7 +169,7 @@ map<string|string[]> accHeaders = {};
 var response = myclient->post("/some/endpoint", payload, headers = accHeaders);
 ```
 
-Improve the data types of outbound request/response payloads which can be set directly.  
+Improved the data types of outbound request/response payloads which can be set directly.  
 ```ballerina
 type RequestMessage Request|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
                       (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error>|();
@@ -178,9 +178,9 @@ type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|m
                       (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error>|();
 ```
 
-Mark HTTP client remote methods as isolated.
+Marked HTTP client remote methods as isolated.
 
-Introduce module error inheritance and remove error union types.
+Introduced module error inheritance and remove error union types.
 
 ##### WebSocket Package Updates
 
@@ -199,7 +199,7 @@ websocket:ClientConfiguration clientConf = {
 websocket:Client wsClient = check new ("ws://localhost:21316/ws", config = clientConf);
 ```
 
-Make the `websocket:Caller` optional in WebSocket service remote functions.
+Made the `websocket:Caller` optional in WebSocket service remote functions.
 
 Introduced support to send text, binary, and pong messages by returning them from the remote methods. 
 Users can send text/binary data to the peer by returning a `string` or a `byte[]` value from the `onTextMessage` and `onBinaryMessage` remote methods. And users can send a pong frame to the peer by returning a `byte[]` value from the `onPing` remote method.
@@ -218,7 +218,7 @@ Removed the support for `websocket:AsyncClient`.
 
 ##### GraphQL Package Updates
 
-Add support for hierarchical resource paths.
+Added the support for hierarchical resource paths.
 The Ballerina GraphQL resources now can have hierarchical resource paths. Each intermediate resource path then maps to a new type in the generated schema.
 ```ballerina
 import ballerina/graphql;
@@ -238,7 +238,7 @@ service /graphql on new Listener(9104) {
 }
 ```
 
-Support resource functions to return optional types. 
+Supported resource functions to return optional types. 
 
 The Ballerina GraphQL resources now can return optional types. 
 ```ballerina
@@ -251,7 +251,7 @@ resource function get profile/name/first(int id) returns string? {
 
 ##### Email Package Updates
 
-Enable read/listen for multiple emails in a single TCP connection.
+Enabled read/listen for multiple emails in a single TCP connection.
 Each POP3 or IMAP client/listener creation initiates the connection.
 Then email sending, receiving or listening operation can be performed many times.
 Finally the client/listener has to be closed.
@@ -285,15 +285,15 @@ service object {} emailObserver = service object {
 
 Note how the `close()` method calls the `onClose` method in the service.
 
-Make email body a mandatory field in `sendEmail` method API.
+Made email body a mandatory field in `sendEmail` method API.
 
-Rename email sending method names removing `Email` in each of them 
-Rename `sendEmail` as `send`, `sendEmailMessage` as `sendMessage`, `receiveEmailMessage` as `receiveMessage` and `onEmailMessage` as `onMessage`.
+Renamed email sending method names removing `Email` in each of them 
+Renamed `sendEmail` as `send`, `sendEmailMessage` as `sendMessage`, `receiveEmailMessage` as `receiveMessage` and `onEmailMessage` as `onMessage`.
 
 Set default `from` address of `email:Message` record from the `SmtpClient` authentication field, `username`.
 Earlier the username for authentication was decoupled from message data. Now the field `from` is made optional and default value will be set from the username.
 
-Make POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument
+Made POP3 and IMAP clients as blocking clients by providing an optional `timeout` argument
 Time unit is seconds and the data type is `decimal`. Default value is 0 where the inbuilt polling interval is 100 milliseconds.
 A sample client code is as follows.
 ```ballerina
@@ -301,15 +301,15 @@ email:Message|email:Error? email = popClient->receiveMessage(timeout = 2);
 ```
 In `PopListener` and `ImapListener` configuration polling interval is not set with `decimal` type in seconds to the field, `pollingInterval`, which was earlier named as `pollingIntervalInMillis`.
 
-Rename `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig` and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration` and `email:ImapListenerConfiguration` respectively.
+Renamed `email:SmtpConfig`, `email:PopConfig`, `email:ImapConfig`, `email:PopListenerConfig` and `email:ImapListenerConfiguration` as `email:SmtpConfiguration`, `email:PopConfiguration`, `email:ImapConfiguration`, `email:PopListenerConfiguration` and `email:ImapListenerConfiguration` respectively.
 
-Remove the field, `cronExpression` from `email:ImapListenerConfig` and `email:PopListenerConfig`.
+Removed the field, `cronExpression` from `email:ImapListenerConfig` and `email:PopListenerConfig`.
 
-Make the `body` field of `send` method mandatory in `email:SmtpClient`. 
+Made the `body` field of `send` method mandatory in `email:SmtpClient`. 
 
 ##### WebSub Package Updates
 
-Add websub-listener-configuration for websub-listener
+Introduced websub-listener-configuration for websub-listener
 ```ballerina
 import ballerina/websub;
 
@@ -330,7 +330,7 @@ service /subscriber on new websub:Listener(9090, configs) {
 
 ##### WebSubHub Package Updates
 
-Include HTTP Headers parameter into WebSub Hub API
+Included HTTP Headers parameter into WebSub Hub API
 ```ballerina
 import ballerina/websubhub;
 import ballerina/http;
@@ -346,7 +346,7 @@ service /websubhub on new websubhub:Listener(9090) {
 }
 ```
 
-Introduce pre-initialized constant responses to be used in `websubhub:Service` implementation
+Introduced pre-initialized constant responses to be used in `websubhub:Service` implementation
 ```ballerina
 import ballerina/websubhub;
 
@@ -384,7 +384,7 @@ websubhub:ContentDistributionMessage msg = {content: "This is sample content del
 var publishResponse = hubClientEP->notifyContentDistribution(msg);
 ```
 
-Introduce websubhub listener configuration to configure websubhub listener. 
+Introduced websubhub listener configuration to configure websubhub listener. 
 ```ballerina
 import ballerina/websubhub;
 
@@ -488,7 +488,7 @@ Added support for OAuth2 client authentication of JDK11 client, which is used to
 
 ##### TCP Package Updates
 
-Introduce SSL/TLS support for both the client and listener.
+Introduced SSL/TLS support for both the client and listener.
 ```ballerina
 import ballerina/tcp;
 
@@ -509,7 +509,6 @@ public function main() returns error? {
     check socketClient->writeBytes(msgByteArray);
 
     readonly & byte[] receivedData = check socketClient->readBytes();
-    test:assertEquals('string:fromBytes(receivedData), msg, "Found unexpected output");
 
     check socketClient->close();
 }
@@ -546,7 +545,7 @@ service class EchoService {
 }
 ```
 
-Include tcp:Caller as an optional parameter in onBytes() method.
+Included tcp:Caller as an optional parameter in onBytes() method.
 ```
 service class EchoService {
   
@@ -559,31 +558,31 @@ service class EchoService {
 
 ##### Kafka Package Updates
 
-Rename `sendProducerRecord` function in the client object `Producer` to `send`.
+Renamed `sendProducerRecord` function in the client object `Producer` to `send`.
 
-Rename `flushRecords` function in the client object `Producer` to `’flush`.
+Renamed `flushRecords` function in the client object `Producer` to `’flush`.
 
-Replace `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
+Replaced `kafka:ConsumerError` and `kafka:ProducerError` with `kafka:Error`.
 
 ##### NATS Package Updates
 
-Rename `ConnectionConfig` record to `ConnectionConfiguration`. 
+Renamed `ConnectionConfig` record to `ConnectionConfiguration`. 
 
-Include `url` as a field in `ConnectionConfiguration` record. 
+Included `url` as a field in `ConnectionConfiguration` record. 
 
-Change `ConnectionConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
+Changed `ConnectionConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
 
 ##### STAN Package Updates
 
-Rename `StreamingConfig` record to `StreamingConfiguration`. 
+Renamed `StreamingConfig` record to `StreamingConfiguration`. 
 
-Include `url` as a field in `StreamingConfiguration` record. 
+Included `url` as a field in `StreamingConfiguration` record. 
 
-Change `StreamingConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
+Changed `StreamingConfiguration` in client and listener init functions to an included record parameter. This allows the users to pass the record field values as named parameters. 
 
 ##### RabbitMQ Package Updates
 
-Rename `ConnectionConfig` record to `ConnectionConfiguration`. 
+Renamed `ConnectionConfig` record to `ConnectionConfiguration`. 
 
 ###### Common Standard Library Updates
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -146,7 +146,7 @@ io:println(nameText); // "DanBrown"
 
 ##### HTTP Package Updates
 
-Changed the return types of client methods to depend on the `targetType` argument. The default `targetType` is `http:Response`.
+Changed the return types of the client methods to depend on the `targetType` argument. The default `targetType` is `http:Response`.
 ```ballerina 
 http:Client myClient = check new ("http://localhost:9090”);
 http:Response response = check myClient->post("/backend/getResponse", "want response");
@@ -154,10 +154,10 @@ json jsonPayload = check myClient->post("/backend/getJson", "want json", targetT
 xml xmlPayload = check myClient->post("/backend/getXml", "want xml", targetType = xml);
 ```
 
-Introduced header map as an optional argument for non-entity body client remote methods (GET, HEAD, OPTIONS). 
+Introduced a header map as an optional argument for non-entity-body client remote methods (GET, HEAD, OPTIONS). 
 ```ballerina
 http:Client myClient = check new ("http://localhost:9090”);
-map<string|string[]> accHeaders = {};
+map<string|string[]> accHeaders = { "Accept" : "application/json" };
 var response = myclient->get("/some/endpoint", accHeaders);
 ```
 
@@ -165,14 +165,14 @@ Introduced header map and media type as optional arguments for entity body clien
 ```ballerina
 http:Client myClient = check new ("http://localhost:9090”);
 json payload = {}; 
-map<string|string[]> accHeaders = {};
+map<string|string[]> accHeaders = { "Accept" : "application/json" };
 var response = myclient->post("/some/endpoint", payload, headers = accHeaders);
 ```
 
 Improved the data types of outbound request/response payloads which can be set directly.  
 ```ballerina
-type RequestMessage Request|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
-                      (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error>|();
+type RequestMessage Request|string|xml|json[]|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
+                      table<map<json>>[]|mime:Entity[]|stream<byte[], io:Error>|();
 
 type ResponseMessage Response|string|xml|json|byte[]|int|float|decimal|boolean|map<json>|table<map<json>>|
                       (map<json>|table<map<json>>)[]|mime:Entity[]|stream<byte[], io:Error>|();

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -146,24 +146,24 @@ io:println(nameText); // "DanBrown"
 
 ##### HTTP Package Updates
 
-Change the return type of client method to depend on `targetType` arg. The default targetType is `http:Response`
+Changed the return types of client methods to depend on the `targetType` argument. The default `targetType` is `http:Response`.
 ```ballerina 
-http:Client myClient = check new("http://localhost:9090”);
-http:Response v = check myClient->post("/backend/getResponse", "want response");
-json p = check myClient->post("/backend/getJson", "want json", targetType = json);
-xml q = check myClient->post("/backend/getXml", "want xml", targetType = xml);
+http:Client myClient = check new ("http://localhost:9090”);
+http:Response response = check myClient->post("/backend/getResponse", "want response");
+json jsonPayload = check myClient->post("/backend/getJson", "want json", targetType = json);
+xml xmlPayload = check myClient->post("/backend/getXml", "want xml", targetType = xml);
 ```
 
-Introduce header map as an optional argument for Non-entity body client remote method(GET, HEAD, OPTIONS) 
+Introduced header map as an optional argument for non-entity body client remote methods (GET, HEAD, OPTIONS). 
 ```ballerina
-http:Client myClient = check new("http://localhost:9090”);
+http:Client myClient = check new ("http://localhost:9090”);
 map<string|string[]> accHeaders = {};
 var response = myclient->get("/some/endpoint", accHeaders);
 ```
 
-Introduce header map and media type as optional arguments for Entity body client remote method(POST, PUT, PATCH, DELETE, EXECUTE)
+Introduce header map and media type as optional arguments for entity body client remote methods (POST, PUT, PATCH, DELETE, EXECUTE).
 ```ballerina
-http:Client myClient = check new("http://localhost:9090”);
+http:Client myClient = check new ("http://localhost:9090”);
 json payload = {}; 
 map<string|string[]> accHeaders = {};
 var response = myclient->post("/some/endpoint", payload, headers = accHeaders);
@@ -185,7 +185,7 @@ Introduce module error inheritance and remove error union types.
 ##### WebSocket Package Updates
 
 Introduced auth support for the websocket client.
-Bearer token, Basic auth, JWT and OAuth2 support has been introduced with the websocket client declarative authentication.
+Bearer token, Basic auth, JWT, and OAuth2 support has been introduced with the WebSocket client declarative authentication.
 
 Introduced HTTP cookie support for the WebSocket client.
 ```ballerina
@@ -196,16 +196,16 @@ websocket:ClientConfiguration clientConf = {
   cookies: httpCookies
 };
 
-websocket:Client wsClient = check new("ws://localhost:21316/ws", config = clientConf);
+websocket:Client wsClient = check new ("ws://localhost:21316/ws", config = clientConf);
 ```
 
 Make the `websocket:Caller` optional in WebSocket service remote functions.
 
-Introduced the support to send text/binary/pong messages by returning them from the remote functions. 
-Users can send text/binary data to the peer by returning a `string` or a `byte[]` from `onTextMessage` and `onBinarymessage` remote functions. And users can send a pong frame to the peer by returning a `byte[]` from the `onPing` remote function.
+Introduced support to send text, binary, and pong messages by returning them from the remote methods. 
+Users can send text/binary data to the peer by returning a `string` or a `byte[]` value from the `onTextMessage` and `onBinaryMessage` remote methods. And users can send a pong frame to the peer by returning a `byte[]` value from the `onPing` remote method.
 ```ballerina
 remote function onTextMessage(string text) returns string {
-    return “Hello World!”;
+    return "Hello World!";
 }
 ```
 ```ballerina
@@ -243,15 +243,15 @@ Support resource functions to return optional types.
 The Ballerina GraphQL resources now can return optional types. 
 ```ballerina
 resource function get profile/name/first(int id) returns string? {
-    if (id == 0) {
-        return “sherlock”;
+    if id == 0 {
+        return "sherlock";
     }
 }
 ```
 
 ##### Email Package Updates
 
-Enable to read/listen multiple emails in a single TCP connection
+Enable read/listen for multiple emails in a single TCP connection.
 Each POP3 or IMAP client/listener creation initiates the connection.
 Then email sending, receiving or listening operation can be performed many times.
 Finally the client/listener has to be closed.
@@ -283,9 +283,9 @@ service object {} emailObserver = service object {
 };
 ```
 
-Note how that `close()` method calls the `onClose` method in the service.
+Note how the `close()` method calls the `onClose` method in the service.
 
-Make email body a mandatory field in `sendEmail` method API 
+Make email body a mandatory field in `sendEmail` method API.
 
 Rename email sending method names removing `Email` in each of them 
 Rename `sendEmail` as `send`, `sendEmailMessage` as `sendMessage`, `receiveEmailMessage` as `receiveMessage` and `onEmailMessage` as `onMessage`.


### PR DESCRIPTION
## Purpose
This PR includes updates related to following standard libraries
- HTTP
- WebSocket
- GraphQL
- Email
- TCP
- UDP
- WebSub
- WebSubHub
- NATS
- STAN
- Kafka
- RabbitMq