### PR TITLE
Add standard library DUI  content to the release note

### DIFF
--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -179,6 +179,8 @@ The module has been revamped by removing the `Scheduler` and `Listener` classes 
 
 - Configures the scheduler worker pool with the worker count and max waiting time.
 ```ballerina
+import ballerina/task;
+
 task:Error? output = task:configureWorkerPool(6, 7000);
 ```
 
@@ -270,37 +272,39 @@ task:Error? result = task:getRunningJobs();
 Revamped the entire time package as follows:
 
 - Introduced the `time:Utc` record to represent the UTC timestamp.
-- Introduced `time:Civil` to represent the localized time.
+- Introduced the `time:Civil` record to represent the localized time.
 - Added necessary APIs to do time generation, manipulations, and conversions.
 
 Steps for migration from the previous version to the current version are listed [here](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
 
 #### Cache Package Updates
 
-- Introduced the new configuration as `EvictionPolicy` to set the eviction policy in the `CacheConfig` record.
+- Introduced the new `EvictionPolicy` configuration to set the eviction policy in the `CacheConfig` record.
 
 The `EvictionPolicy` record has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
 
 - Removed the `AbstractEvictionPolicy` object.
 
-This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed by introducing the above configuration.
+This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed with the introduction of the above configuration.
 
 #### New `xmldata` Package
 
-A new module is added to convert a natural representation of data in XML into a natural representation of data in JSON and vice-versa.
+A new module is added to convert data in XML format to JSON format and vice-versa.
 
 - Converts a JSON object to an XML representation.
 ```ballerina
+import ballerina/xmldata;
+
 json data = {
     name: "John",
     age: 30
 };
-xml|Error x = fromJson(data);
+xml|xmldata:Error x = xmldata:fromJson(data);
 ```
 
 - Converts an XML value to its JSON representation.
 ```ballerina
-json|Error j = toJson(xml `foo`);
+json|xmldata:Error j = xmldata:toJson(xml `foo`);
 ```
 
 #### Remove `jsonutils`, `xmlutils`, `runtime`, and `reflect` Packages

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -270,7 +270,7 @@ This object had the common APIs for the cache eviction functionalities to implem
 
 #### New `xmldata` Package
 
-A new module is added to convert a natural representation of data in XML into a natural representation of data in JSON and vice-versa
+A new module is added to convert a natural representation of data in XML into a natural representation of data in JSON and vice-versa.
 
 - Converts a JSON object to an XML representation.
 ```ballerina

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -285,7 +285,7 @@ The `EvictionPolicy` record has been introduced with the option `LRU` as the mod
 
 - Removed the `AbstractEvictionPolicy` object type.
 
-This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed with the introduction of the above configuration.
+This object type had the common APIs for the cache eviction functionalities to implement a custom eviction policy. It has been removed with the introduction of the above configuration.
 
 #### New `xmldata` Package
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -175,7 +175,7 @@ level = "[LOG_LEVEL]"
 
 #### Task Package Updates
 
-The module has been revamped by removing `Scheduler` and `Listener` classes and introducing the following functions to schedule and manage the job either one-time or periodically.
+The module has been revamped by removing the `Scheduler` and `Listener` classes and introducing the following functions to schedule and manage the job either one-time or periodically.
 
 - Configure the scheduler worker pool with worker count and max waiting time.
 ```ballerina

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -177,7 +177,7 @@ level = "[LOG_LEVEL]"
 
 The module has been revamped by removing the `Scheduler` and `Listener` classes and introducing the following functions to schedule and manage the job either one-time or periodically.
 
-- Configure the scheduler worker pool with worker count and max waiting time.
+- Configure the scheduler worker pool with the worker count and max waiting time.
 ```ballerina
 task:Error? output = task:configureWorkerPool(6, 7000);
 ```

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -152,9 +152,145 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Alpha3](https://githu
 
 #### Standard Library
 
-##### Bug Fixes
+##### Log Package Updates
 
-To view bug fixes, see the [GitHub milestone for Swan Lake Alpha3](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+milestone%3A%22Swan+Lake+Alpha3%22).
+###### Introduce additional log levels and log functions
+
+There are 4 log levels: `DEBUG`, `ERROR`, `INFO`,and `WARN` and their respective functions: `printDebug`, `printError`, `printInfo`, and `printWarn`. To set the global log level, place the entry given below in the `Config.toml` file:
+```
+[log] 
+level = "[LOG_LEVEL]"
+```
+
+Each module can also be assigned its own log level. To assign a log level to a module, provide the following entry in the `Config.toml` file:
+```
+[[log.modules]] 
+name = "[MODULE_NAME]" 
+level = "[LOG_LEVEL]"
+```
+
+#### OS Package Updates
+
+- Removed the `exec` function.
+
+#### Task Package Updates
+
+The module has been revamped by removing `Scheduler` and `Listener` classes and introducing the following functions to schedule and manage the job either one-time or periodically.
+
+- Configure the scheduler worker pool with worker count and max waiting time.
+```ballerina
+task:Error? output = task:configureWorkerPool(6, 7000);
+```
+
+- Schedule the Ballerina job at specified time.
+```ballerina
+class MyJob {
+   *task:Job;
+
+   public function execute() {
+       // logic goes here
+   }
+}
+
+ZoneOffset zoneOffset = {hours: 5, minutes: 30};
+Civil time = {
+    year: 2021,
+    month: 4,
+    day: 12,
+    hour: 23,
+    minute: 20,
+    second: 50.52,
+    timeAbbrev: "Asia/Colombo",
+    utcOffset: zoneOffset
+};
+task:Error|task:JobId id = task:scheduleOneTimeJob(new MyJob(), time);
+```
+
+- Schedule the recurring Ballerina job according to the given duration.
+```ballerina
+class MyJob {
+   *task:Job;
+
+   public function execute() {
+       // logic goes here
+   }
+}
+task:Error|task:JobId id = task:scheduleJobRecurByFrequency(new MyJob(), 1);
+```
+
+- Unschedule the particular `job`.
+```ballerina
+task:Error? result = unscheduleJob(id);
+```
+
+- Pauses all the jobs.
+```ballerina
+task:Error? result = pauseAllJobs();
+```
+
+- Resumes all the jobs.
+```ballerina
+task:Error? result = resumeAllJobs();
+```
+
+- Pauses the particular job.
+```ballerina
+task:Error? result = pauseJob(id);
+```
+
+- Resumes the particular job.
+```ballerina
+task:Error? result = resumeJob(id);
+```
+
+- Gets all the running jobs.
+```ballerina
+task:Error? result = getRunningJobs();
+```
+
+#### Time Package Updates
+
+Revamped the entire time package as follows:
+
+- Introduced `time:Utc` to represent the UTC timestamp.
+- Introduced `time:Civil` to represent the localized time.
+- Added necessary APIs to do time generation, manipulations, and conversions.
+
+Necessary migrations steps from the previous version to the current version are listed [here](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
+
+#### Cache Package Updates
+
+- Introduced the new configuration as `EvictionPolicy` to set the eviction policy in the `CacheConfig`.
+
+The `EvictionPolicy` has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
+
+- Removed the `AbstractEvictionPolicy` Object.
+
+This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed by introducing the above configuration.
+
+#### New `xmldata` Package
+
+A new module is added to convert a natural representation of data in XML into a natural representation of data in JSON and vice-versa
+
+- Converts a JSON object to an XML representation.
+```ballerina
+json data = {
+    name: "John",
+    age: 30
+};
+xml|Error x = fromJson(data);
+```
+
+- Converts an XML object to its JSON representation.
+```ballerina
+json|Error j = toJson(xml `foo`);
+```
+
+#### Remove `jsonutils`, `xmlutils`, `runtime`, and `reflect` Packages
+
+The `jsonutils`, `xmlutils`, `runtime` and `reflect` packages are removed from Standard Libraries.
+
+The XML/JSON conversation APIs in `jsonutils`, `xmltutils` packages are now supported in `xmldata` package.
 
 ##### HTTP Package Updates
 
@@ -599,6 +735,10 @@ service class EchoService {
 ###### Common Standard Library Updates
 
 ###### All the timeout configurations are converted to accept decimal values and the time unit is in seconds.
+
+##### Bug Fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Alpha3](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+milestone%3A%22Swan+Lake+Alpha3%22).
 
 #### Code to Cloud
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -156,7 +156,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Alpha3](https://githu
 
 ###### Introduce additional log levels and log functions
 
-There are 4 log levels: `DEBUG`, `ERROR`, `INFO`,and `WARN` and their respective functions: `printDebug`, `printError`, `printInfo`, and `printWarn`. To set the global log level, place the entry given below in the `Config.toml` file:
+There are 4 log levels: `DEBUG`, `ERROR`, `INFO`, and `WARN` and their respective functions: `printDebug`, `printError`, `printInfo`, and `printWarn`. To set the global log level, place the entry given below in the `Config.toml` file:
 ```
 [log] 
 level = "[LOG_LEVEL]"

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -182,7 +182,7 @@ The module has been revamped by removing the `Scheduler` and `Listener` classes 
 task:Error? output = task:configureWorkerPool(6, 7000);
 ```
 
-- Schedule the Ballerina job at specified time.
+- Schedule the Ballerina job at a specified time.
 ```ballerina
 class MyJob {
    *task:Job;

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -163,7 +163,7 @@ level = "[LOG_LEVEL]"
 ```
 
 Each module can also be assigned its own log level. To assign a log level to a module, provide the following entry in the `Config.toml` file:
-```
+```toml
 [[log.modules]] 
 name = "[MODULE_NAME]" 
 level = "[LOG_LEVEL]"

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -290,7 +290,7 @@ json|Error j = toJson(xml `foo`);
 
 The `jsonutils`, `xmlutils`, `runtime`, and `reflect` packages are removed from Standard Libraries.
 
-The XML/JSON conversation APIs in `jsonutils`, `xmltutils` packages are now supported in `xmldata` package.
+The XML/JSON conversation APIs in `jsonutils` and `xmltutils` packages are now supported by the `xmldata` package.
 
 ##### HTTP Package Updates
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -288,7 +288,7 @@ json|Error j = toJson(xml `foo`);
 
 #### Remove `jsonutils`, `xmlutils`, `runtime`, and `reflect` Packages
 
-The `jsonutils`, `xmlutils`, `runtime` and `reflect` packages are removed from Standard Libraries.
+The `jsonutils`, `xmlutils`, `runtime`, and `reflect` packages are removed from Standard Libraries.
 
 The XML/JSON conversation APIs in `jsonutils`, `xmltutils` packages are now supported in `xmldata` package.
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -283,7 +283,7 @@ Steps for migration from the previous version to the current version are listed 
 
 The `EvictionPolicy` record has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
 
-- Removed the `AbstractEvictionPolicy` object.
+- Removed the `AbstractEvictionPolicy` object type.
 
 This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed with the introduction of the above configuration.
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -275,7 +275,7 @@ Revamped the entire time package as follows:
 - Introduced the `time:Civil` record to represent the localized time.
 - Added necessary APIs to do time generation, manipulations, and conversions.
 
-Steps for migration from the previous version to the current version are listed [here](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
+Steps for migration from the previous version to the current version are listed [in this issue](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
 
 #### Cache Package Updates
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -304,6 +304,8 @@ xml|xmldata:Error x = xmldata:fromJson(data);
 
 - Converts an XML value to its JSON representation.
 ```ballerina
+import ballerina/xmldata;
+
 json|xmldata:Error j = xmldata:toJson(xml `foo`);
 ```
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -264,7 +264,7 @@ Necessary migrations steps from the previous version to the current version are 
 
 The `EvictionPolicy` has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
 
-- Removed the `AbstractEvictionPolicy` Object.
+- Removed the `AbstractEvictionPolicy` object.
 
 This object had the common APIs for the cache eviction functionalities to implement the custom eviction policy. It has been removed by introducing the above configuration.
 

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -177,13 +177,16 @@ level = "[LOG_LEVEL]"
 
 The module has been revamped by removing the `Scheduler` and `Listener` classes and introducing the following functions to schedule and manage the job either one-time or periodically.
 
-- Configure the scheduler worker pool with the worker count and max waiting time.
+- Configures the scheduler worker pool with the worker count and max waiting time.
 ```ballerina
 task:Error? output = task:configureWorkerPool(6, 7000);
 ```
 
-- Schedule the Ballerina job at a specified time.
+- Schedules the Ballerina job at a specified time.
 ```ballerina
+import ballerina/task;
+import ballerina/time;
+
 class MyJob {
    *task:Job;
 
@@ -192,8 +195,8 @@ class MyJob {
    }
 }
 
-ZoneOffset zoneOffset = {hours: 5, minutes: 30};
-Civil time = {
+time:ZoneOffset zoneOffset = {hours: 5, minutes: 30};
+time:Civil time = {
     year: 2021,
     month: 4,
     day: 12,
@@ -206,8 +209,10 @@ Civil time = {
 task:Error|task:JobId id = task:scheduleOneTimeJob(new MyJob(), time);
 ```
 
-- Schedule the recurring Ballerina job according to the given duration.
+- Schedules the recurring Ballerina job according to the given duration.
 ```ballerina
+import ballerina/task;
+
 class MyJob {
    *task:Job;
 
@@ -218,51 +223,63 @@ class MyJob {
 task:Error|task:JobId id = task:scheduleJobRecurByFrequency(new MyJob(), 1);
 ```
 
-- Unschedule the particular `job`.
+- Unschedules the particular job.
 ```ballerina
-task:Error? result = unscheduleJob(id);
+import ballerina/task;
+
+task:Error? result = task:unscheduleJob(id);
 ```
 
 - Pauses all the jobs.
 ```ballerina
-task:Error? result = pauseAllJobs();
+import ballerina/task;
+
+task:Error? result = task:pauseAllJobs();
 ```
 
 - Resumes all the jobs.
 ```ballerina
-task:Error? result = resumeAllJobs();
+import ballerina/task;
+
+task:Error? result = task:resumeAllJobs();
 ```
 
 - Pauses the particular job.
 ```ballerina
-task:Error? result = pauseJob(id);
+import ballerina/task;
+
+task:Error? result = task:pauseJob(id);
 ```
 
 - Resumes the particular job.
 ```ballerina
-task:Error? result = resumeJob(id);
+import ballerina/task;
+
+task:Error? result = task:resumeJob(id);
 ```
 
 - Gets all the running jobs.
 ```ballerina
-task:Error? result = getRunningJobs();
+import ballerina/task;
+
+task:Error? result = task:getRunningJobs();
 ```
 
 #### Time Package Updates
 
 Revamped the entire time package as follows:
 
-- Introduced `time:Utc` to represent the UTC timestamp.
+- Introduced the `time:Utc` record to represent the UTC timestamp.
 - Introduced `time:Civil` to represent the localized time.
 - Added necessary APIs to do time generation, manipulations, and conversions.
 
-Necessary migrations steps from the previous version to the current version are listed [here](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
+Steps for migration from the previous version to the current version are listed [here](https://github.com/ballerina-platform/ballerina-standard-library/issues/1079).
 
 #### Cache Package Updates
 
-- Introduced the new configuration as `EvictionPolicy` to set the eviction policy in the `CacheConfig`.
+- Introduced the new configuration as `EvictionPolicy` to set the eviction policy in the `CacheConfig` record.
 
-The `EvictionPolicy` has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
+The `EvictionPolicy` record has been introduced with the option `LRU` as the module only supports the LRU eviction policy to evict the cache data when the cache is full.
 
 - Removed the `AbstractEvictionPolicy` object.
 
@@ -281,7 +298,7 @@ json data = {
 xml|Error x = fromJson(data);
 ```
 
-- Converts an XML object to its JSON representation.
+- Converts an XML value to its JSON representation.
 ```ballerina
 json|Error j = toJson(xml `foo`);
 ```

--- a/release-notes/swan-lake-alpha3-release-note.md
+++ b/release-notes/swan-lake-alpha3-release-note.md
@@ -157,7 +157,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Alpha3](https://githu
 ###### Introduce additional log levels and log functions
 
 There are 4 log levels: `DEBUG`, `ERROR`, `INFO`, and `WARN` and their respective functions: `printDebug`, `printError`, `printInfo`, and `printWarn`. To set the global log level, place the entry given below in the `Config.toml` file:
-```
+```toml
 [log] 
 level = "[LOG_LEVEL]"
 ```


### PR DESCRIPTION
## Purpose
This PR includes updates related to the following standard libraries

- Log
- OS
- Task
- Time
- Cache
- Xmldata

And details related to the removed packages

- jsonutils
- xmlutils
- runtime
- reflect