### PR TITLE
Enable ballerina version auto bump in connectors

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -1,9 +1,73 @@
 {
-    "auto_bump": false,
+    "auto_bump": true,
     "modules": [
         {
             "name": "module-ballerinax-slack",
-            "auto_merge": false
-        }
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-github",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-twilio",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-googleapis.sheets",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-googleapis.gmail",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-googleapis.drive",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-googleapis.calendar",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-sfdc",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-netsuite",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-azure.eventhub",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-azure-cosmosdb",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-azure-service-bus",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-azure-storage-service",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-mongodb",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-aws.s3",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-aws.sqs",
+            "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-googleapis.people",
+            "auto_merge": true
+        } 
     ]
 }


### PR DESCRIPTION
## Purpose
Enable ballerina version auto bump in connector repos

## Description
This is to enable auto bump of the `ballerinaLangVersion` specified in gradle.properties file of each connector repositories

## Related PRs
> https://github.com/ballerina-platform/ballerina-release/pull/264

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes