### PR TITLE
[Connectors] Temporarily disable ballerina lang version auto bump

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -1,5 +1,5 @@
 {
-    "auto_bump": true,
+    "auto_bump": false,
     "modules": [
         {
             "name": "module-ballerinax-slack",


### PR DESCRIPTION
## Purpose
Temporarily disable ballerina lang version auto bump for connectors.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
