### PR TITLE
Enable ballerina-lang version auto bump for connectors

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -1,5 +1,5 @@
 {
-    "auto_bump": false,
+    "auto_bump": true,
     "modules": [
         {
             "name": "module-ballerinax-slack",
@@ -34,15 +34,7 @@
             "auto_merge": true
         },
         {
-            "name": "module-ballerinax-netsuite",
-            "auto_merge": true
-        },
-        {
             "name": "module-ballerinax-azure.eventhub",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-azure-cosmosdb",
             "auto_merge": true
         },
         {
@@ -50,24 +42,8 @@
             "auto_merge": true
         },
         {
-            "name": "module-ballerinax-azure-storage-service",
-            "auto_merge": true
-        },
-        {
             "name": "module-ballerinax-mongodb",
             "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-aws.s3",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-aws.sqs",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-googleapis.people",
-            "auto_merge": true
-        } 
+        }
     ]
 }


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2-enterprise/choreo/issues/6309
Enable ballerina-lang version auto bump for connectors

## Goals
- Enable ballerina-lang version auto bump for connectors
- Remove unnecessary connectors in `connector_list.json` since those connectors don't use ballerina-lang version

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
Earlier this was disabled in https://github.com/ballerina-platform/ballerina-release/pull/512

