### PR TITLE
Enable ballerina-lang version bump for Twitter Connector

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -44,6 +44,10 @@
         {
             "name": "module-ballerinax-mongodb",
             "auto_merge": true
+        },
+        {
+            "name": "module-ballerinax-twitter",
+            "auto_merge": true
         }
     ]
 }


### PR DESCRIPTION
## Purpose
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/70

## Description
- This is to enable auto bump of the `ballerinaLangVersion` specified in gradle.properties file of Twitter Connector Repo.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes