### PR TITLE
[Connectors] Temporarily disable ballerina lang version auto bump

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -1,5 +1,5 @@
 {
-    "auto_bump": true,
+    "auto_bump": false,
     "modules": [
         {
             "name": "module-ballerinax-slack",


### PR DESCRIPTION
## Purpose
Already the connectors are updated with ballerinaLang `2.0.0-beta.3`

We need to temporarily disable ballerinaLang version auto-bump because this script will update the slbeta4 version.
After connector team completes the `slbeta3` release, this script can be enabled again

## Related PR
Last time also (during SLBeta2 release) we did this same thing temporarily
https://github.com/ballerina-platform/ballerina-release/pull/512

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
