### PR TITLE
Enable bal-lang version auto-bump for connectors

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -1,5 +1,5 @@
 {
-    "auto_bump": false,
+    "auto_bump": true,
     "modules": [
         {
             "name": "module-ballerinax-slack",


### PR DESCRIPTION
## Purpose
- Enable ballerinaLang version auto-bump for connectors

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- It was temporarily disabled via https://github.com/ballerina-platform/ballerina-release/pull/1182 until slbeta3 release of connectors are finished
