### PR TITLE
Change the OpenAPI repository name in `module_list.json` file

### DIFF
--- a/dependabot/resources/module_list.json
+++ b/dependabot/resources/module_list.json
@@ -117,7 +117,7 @@
             "version_key": "stdlibOAuth2Version"
         },
         {
-            "name": "ballerina-openapi",
+            "name": "openapi-tools",
             "group_id": "io.ballerina",
             "artifact_id": "module-ballerina-openapi",
             "version_key": "openapiVersion"


### PR DESCRIPTION
## Purpose
> Change the openAPI repository name `ballerina-openapi` into `openapi-tools` .