### PR TITLE
Remove bal version bump for azure eventhub

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -34,10 +34,6 @@
             "auto_merge": true
         },
         {
-            "name": "module-ballerinax-azure.eventhub",
-            "auto_merge": true
-        },
-        {
             "name": "module-ballerinax-azure-service-bus",
             "auto_merge": true
         },


### PR DESCRIPTION
## Purpose
- Remove ballerinaLang version bump for `azure eventhub` connector since it doesn't require it.
