### PR TITLE
Create a workflow to push stdlibs to stage and dev centrals

### DIFF
--- a/.github/workflows/push_stdlibs_to_stage_dev_central.yml
+++ b/.github/workflows/push_stdlibs_to_stage_dev_central.yml
@@ -1,0 +1,49 @@
+name: Push Standard Libraries to Stage and Dev Centrals
+
+on:
+  workflow_dispatch:
+      inputs:
+        releaseVersion:
+          description: 'Version of the release. e.g., swan-lake-beta1'
+          required: true
+        preReleaseSuffix:
+          description: 'The text that will be suffixed to the Git tag. e.g., rc1'
+          required: false
+          default: ''
+
+jobs:
+  push-stdlibs:
+    name: Push Standard Libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install Python Packages
+        run: |
+          pip install requests
+          pip install retry
+          pip install PyGithub
+      - name: Set Version
+        id: set-version
+        run: |
+          RELEASE_VERSION=${{ github.event.inputs.releaseVersion }}
+          TAGGED_VERSION=$RELEASE_VERSION
+          if [ -n "${{ github.event.inputs.preReleaseSuffix }}" ]; then
+            TAGGED_VERSION=$RELEASE_VERSION-${{ github.event.inputs.preReleaseSuffix }}
+          fi
+          echo VERSION=$RELEASE_VERSION >> $GITHUB_ENV
+          echo GIT_TAG=$TAGGED_VERSION >> $GITHUB_ENV
+          echo "::set-output name=version::$RELEASE_VERSION"
+          echo "::set-output name=taggedVersion::$TAGGED_VERSION"
+      - name: Build Modules and Push
+        run: |
+          python dependabot/stage_dev_push_stdlibs.py ${{ steps.set-version.outputs.taggedVersion }}
+        env:
+          BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          BALLERINA_BOT_EMAIL: ${{ secrets.BALLERINA_BOT_EMAIL }}
+          BALLERINA_REVIEWER_BOT_TOKEN: ${{ secrets.BALLERINA_REVIEWER_BOT_TOKEN }}

--- a/dependabot/stage_dev_push_stdlibs.py
+++ b/dependabot/stage_dev_push_stdlibs.py
@@ -1,0 +1,129 @@
+import json
+import requests
+import constants
+import os
+import sys
+import urllib.request
+
+
+stdlib_modules_json_file_url = 'https://raw.githubusercontent.com/ballerina-platform/ballerina-standard-library/' \
+                               'main/release/resources/stdlib_modules.json'
+properties_file_url = "https://raw.githubusercontent.com/ballerina-platform/ballerina-distribution/master/gradle.properties"
+
+release_version = ""
+exit_code = 0
+
+stdlib_module_versions = dict()
+
+ballerina_bot_username = os.environ[constants.ENV_BALLERINA_BOT_USERNAME]
+ballerina_bot_token = os.environ[constants.ENV_BALLERINA_BOT_TOKEN]
+
+
+def main():
+    global stdlib_modules_json_file_url
+    global release_version
+    global properties_file_url
+
+    if len(sys.argv) > 1:
+        release_version = sys.argv[1]
+        properties_file_url = "https://raw.githubusercontent.com/ballerina-platform/ballerina-distribution/v" + \
+                          release_version + "/gradle.properties"
+
+    read_stdlib_version()
+
+    clone_repositories()
+
+    push_stdlibs_to_dev_central()
+    push_stdlibs_to_stage_central()
+
+
+def read_stdlib_version():
+    try:
+        response = requests.get(url=stdlib_modules_json_file_url)
+
+        if response.status_code == 200:
+            stdlib_modules_data = json.loads(response.text)
+            read_version_data(stdlib_modules_data)
+        else:
+            print('Failed to access standard library dependency data from', stdlib_modules_json_file_url)
+            sys.exit(1)
+
+    except json.decoder.JSONDecodeError:
+        print('Failed to load standard library dependency data')
+        sys.exit(1)
+
+
+def read_version_data(stdlib_modules_data):
+    global stdlib_module_versions
+
+    try:
+        req = urllib.request.Request(properties_file_url)
+
+        properties = dict()
+        for line in urllib.request.urlopen(req):
+            line = line.decode("utf-8")
+            if "=" in line:
+                name, value = line.strip().split("=")
+                properties[name] = value
+
+    except:
+        print('Failed to load properties from', properties_file_url)
+        sys.exit(1)
+
+    for module in stdlib_modules_data['modules']:
+        name = module['name']
+        version_key = module['version_key']
+        try:
+            stdlib_module_versions[name] = properties[version_key]
+        except KeyError:
+            if "ballerinax" not in name and "ballerinai" not in name:
+                print('Version key', version_key, 'not found in', properties_file_url)
+                sys.exit(1)
+
+
+def clone_repositories():
+    global exit_code
+
+    # Clone standard library repos
+    for module in stdlib_module_versions:
+        print(f"git clone -b v{stdlib_module_versions[module]} {constants.BALLERINA_ORG_URL}{module}.git")
+        exit_code = os.system(f"git clone -b v{stdlib_module_versions[module]} {constants.BALLERINA_ORG_URL}{module}.git")
+        if exit_code != 0:
+            sys.exit(1)
+
+
+def push_stdlibs_to_dev_central():
+    global exit_code
+
+    # Build standard library repos and push dev central
+    for module in stdlib_module_versions:
+        os.system(f"echo Building Standard Library Module: {module}")
+        exit_code = os.system(f"cd {module}/ballerina;" +
+                              f"export packageUser={ballerina_bot_username};" +
+                              f"export packagePAT={ballerina_bot_token};" +
+                              f"export BALLERINA_DEV_CENTRAL=true;" +
+                              f"export BALLERINA_STAGE_CENTRAL=false;" +
+                              f"bal build;bal pack;bal push")
+        if exit_code != 0:
+            print(f"Build failed for {module}")
+            sys.exit(1)
+
+
+def push_stdlibs_to_stage_central():
+    global exit_code
+
+    # Build standard library repos and push stage central
+    for module in stdlib_module_versions:
+        os.system(f"echo Building Standard Library Module: {module}")
+        exit_code = os.system(f"cd {module}/ballerina;" +
+                              f"export packageUser={ballerina_bot_username};" +
+                              f"export packagePAT={ballerina_bot_token};" +
+                              f"export BALLERINA_DEV_CENTRAL=false;" +
+                              f"export BALLERINA_STAGE_CENTRAL=true;" +
+                              f"bal build;bal pack;bal push")
+        if exit_code != 0:
+            print(f"Build failed for {module}")
+            sys.exit(1)
+
+
+main()


### PR DESCRIPTION
## Purpose
Currently standard libraries are pushed to stage central and dev central manually. Therefore creating a workflow to push standard libraries to stage and dev centrals will automate the process.

## Goals
Automate the process to push standard libraries to stage and dev centrals

## Approach
Using a python script run by a workflow.
A python script has been used to save the tagged versions of standard libraries related to a specific release.
Tagged versions were read by using the gradle.properties file in the specific release branch in ballerina-distribution repository. 

## Fixes
https://github.com/ballerina-platform/ballerina-release/issues/1614