### PR TITLE
Create new workflow to create new lang branch (updated stage)

### DIFF
--- a/.github/workflows/create_stage_lang_branch.yml
+++ b/.github/workflows/create_stage_lang_branch.yml
@@ -1,0 +1,54 @@
+name: Create Lang Branch For Updated Stage
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_lang_branch:
+        description: 'New ballerina-lang branch'
+        required: true
+        default: 'updated-stage-branch'
+
+jobs:
+  create_branch:
+    name: Create New Lang Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Get Stage Version Of Ballerina Language
+        id: stage-version
+        run: |
+          wget https://raw.githubusercontent.com/ballerina-platform/ballerina-distribution/master/gradle.properties
+          STAGE_LANG_VERSION=$((grep -w "ballerinaLangVersion" | cut -d= -f2) < gradle.properties)
+          LANG_VERSION=$((cut -d'-' -f1) <<< $STAGE_LANG_VERSION)
+          COMMIT_ID=${STAGE_LANG_VERSION##*-}
+          isStableVersion=
+          if [[ $LANG_VERSION == $COMMIT_ID ]]; then isStableVersion=true; else isStableVersion=false; fi
+          echo "::set-output name=langVersion::$LANG_VERSION"
+          echo "::set-output name=commitId::$COMMIT_ID"
+          echo "::set-output name=isStableVersion::$isStableVersion"
+
+      - name: Clone Ballerina Lang Repository
+        run: |
+           git clone https://github.com/${{ github.actor }}/ballerina-lang.git || echo "please fork ballerina-lang repository to your github account"
+
+      - name: Create New Lang Branch
+        working-directory: ballerina-lang
+        run:
+          if ( ( ${{steps.stage-version.outputs.isStableVersion}} ) );
+          then git fetch https://github.com/ballerina-platform/ballerina-lang.git release-${{steps.stage-version.outputs.langVersion}}:${{ github.event.inputs.new_lang_branch }} &&
+          git checkout ${{ github.event.inputs.new_lang_branch }};
+          else git fetch https://github.com/ballerina-platform/ballerina-lang.git stage-swan-lake:temporary-lang-branch &&
+          git checkout temporary-lang-branch &&
+          git checkout -b ${{ github.event.inputs.new_lang_branch }} ${{steps.stage-version.outputs.commitId}};
+          fi
+
+      - name: Push New Lang Branch
+        working-directory: ballerina-lang
+        run: |
+          git config remote.origin.url "https://${BALLERINA_BOT_TOKEN}@github.com/${BALLERINA_BOT_USERNAME}/ballerina-lang.git"
+          git push --set-upstream origin ${{ github.event.inputs.new_lang_branch }}
+        env:
+          BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}


### PR DESCRIPTION
## Purpose
>Currently user has to create a new ballerina-lang branch from the last updated stage. With this workflow, users can create a new branch from the last updated stage of ballerina-lang into user's forked repo or to ballerina-platform

## Goals
>Make it easier for users to test full build pipeline for updated stages.

## Approach
>This will clone the user's forked lang repository (if user runs the workflow in his/her forked release repo) or ballerina-platform lang repository.
Then it will check whether the last updated stage for lang is a stable version or a time stamp version.
if it is a stable version, this workflow will fetch the stable version branch into a new branch. Otherwise it will create a new branch from the commit id. 
Then the locally created new branch will be pushed to either ballerina-platform lang repo or user's forked repo.
name for the new branch can be configured as an input to the workflow.

## Fixes
https://github.com/ballerina-platform/ballerina-release/issues/1853