### PR TITLE
Add Graphql client generation tool

### DIFF
--- a/dependabot/resources/extensions.json
+++ b/dependabot/resources/extensions.json
@@ -832,6 +832,19 @@
             "build_action_file": "build-timestamped-master",
             "send_notification": true,
             "dependents": []
+        },
+        {
+            "name": "graphql-tools",
+            "level": 9,
+            "group_id": "io.ballerina",
+            "artifact_id": "graphql-tools",
+            "version_key": "graphqlVersion",
+            "default_branch": "main",
+            "auto_merge": true,
+            "is_extended_library_module": true,
+            "build_action_file": "build-timestamped-master",
+            "send_notification": true,
+            "dependents": []
         }
     ]
 }

--- a/dependabot/resources/module_list.json
+++ b/dependabot/resources/module_list.json
@@ -114,6 +114,12 @@
             "version_key": "stdlibOAuth2Version"
         },
         {
+            "name": "graphql-tools",
+            "group_id": "io.ballerina",
+            "artifact_id": "graphql-tools",
+            "version_key": "graphqlVersion"
+        },
+        {
             "name": "openapi-tools",
             "group_id": "io.ballerina",
             "artifact_id": "module-ballerina-openapi",


### PR DESCRIPTION
## Purpose
> Add GraphQL client generation tool to the Ballerina release

Resolves https://github.com/ballerina-platform/graphql-tools/issues/40

## Goals
> Add GraphQL client generation tool to the Ballerina release

## Approach
> 
Add GraphQL client generation tool to extensions.json and module_list.json

## Release note
> Add GraphQL client generation tool

## Test environment
> 
Ballerina Version: 2201.0.1
Operating System: Ubuntu 20.04
Java SDK: 11