### PR TITLE
Add GraphQL tool Swan Lake 2201.1.0 release note

### DIFF
--- a/release-notes/swan-lake-2201.1.0-release-note.md
+++ b/release-notes/swan-lake-2201.1.0-release-note.md
@@ -100,6 +100,10 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.1.0 of the reposi
 
 #### New Features
 
+##### GraphQL Tool
+
+- Introduced the Ballerina GraphQL tool, which will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. Ballerina Swan Lake supports the GraphQL specification [October 2021 edition](https://spec.graphql.org/October2021/). For more details, see [graphql-tools](https://github.com/ballerina-platform/graphql-tools/blob/main/README.md).
+
 #### Improvements
 
 #### Bug Fixes


### PR DESCRIPTION
## Purpose
> Add GraphQL tool Swan Lake 2201.1.0 release note

Resolves https://github.com/ballerina-platform/graphql-tools/issues/49

## Goals
> Add GraphQL tool Swan Lake 2201.1.0 release note

## Approach
> Add content to swan-lake-2201.1.0-release-note.md

## Release note
> Introduced the Ballerina GraphQL tool for client generation in Ballerina, given the GraphQL schema (SDL) and GraphQL queries.
