### PR TITLE
Update GraphQL tool Swan Lake 2201.1.0 release note

### DIFF
--- a/release-notes/swan-lake-2201.1.0-release-note.md
+++ b/release-notes/swan-lake-2201.1.0-release-note.md
@@ -114,7 +114,7 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.1.0 of the reposi
 
 ##### GraphQL Tool
 
-- Introduced the Ballerina GraphQL tool, which will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. Ballerina Swan Lake supports the GraphQL specification [October 2021 edition](https://spec.graphql.org/October2021/). For more details, see [graphql-tools](https://github.com/ballerina-platform/graphql-tools/blob/main/README.md).
+- Introduced the Ballerina GraphQL tool, which will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. Ballerina Swan Lake supports the GraphQL specification [October 2021 edition](https://spec.graphql.org/October2021/). For more information, see [Ballerina GraphQL support](http://ballerina.io/learn/ballerina-graphql-support/) and [Graphql CLI documentation](http://ballerina.io/learn/cli-documentation/graphql/#graphql-to-ballerina).
 
 #### Improvements
 


### PR DESCRIPTION
## Purpose
> Update GraphQL tool Swan Lake 2201.1.0 release note with learn page links

## Goals
> Update GraphQL tool Swan Lake 2201.1.0 release note

## Approach
> Update GraphQL tool Swan Lake 2201.1.0 release note with learn page links

