### PR TITLE
Disable `ballerinaLang` version bump for selected connectors

### DIFF
--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -2,10 +2,6 @@
     "auto_bump": true,
     "modules": [
         {
-            "name": "module-ballerinax-sfdc",
-            "auto_merge": true
-        },
-        {
             "name": "module-ballerinax-azure-service-bus",
             "auto_merge": true
         },

--- a/dependabot/resources/connector_list.json
+++ b/dependabot/resources/connector_list.json
@@ -2,34 +2,6 @@
     "auto_bump": true,
     "modules": [
         {
-            "name": "module-ballerinax-slack",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-github",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-twilio",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-googleapis.sheets",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-googleapis.gmail",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-googleapis.drive",
-            "auto_merge": true
-        },
-        {
-            "name": "module-ballerinax-googleapis.calendar",
-            "auto_merge": true
-        },
-        {
             "name": "module-ballerinax-sfdc",
             "auto_merge": true
         },


### PR DESCRIPTION
## Purpose
As asyncapi triggers are there separately, we have removed the listener modules from some connectors via https://github.com/wso2-enterprise/choreo/issues/13186.

As a result, these connectors dont require the ballerinaLang version bump anymore. Hence removing them from the list.
