### PR TITLE
Introduce a workflow to automate the build-time stats generation for samples

### DIFF
--- a/.github/workflows/generate-build-time-stats.yml
+++ b/.github/workflows/generate-build-time-stats.yml
@@ -1,0 +1,64 @@
+name: Generate build time statistics 
+
+on: 
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 0' 
+
+jobs: 
+  build-examples:
+    name: Build Examples and Push statistics back to the repo
+    runs-on: ubuntu-latest
+    steps:         
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: build-time-data
+
+      - name: Get the Ballerina examples 
+        run: |
+          git clone https://github.com/ballerina-platform/ballerina-distribution.git
+          cd ballerina-distribution
+          git checkout bbe-refactor
+          cd ..
+          git clone https://github.com/ballerina-platform/nballerina.git
+
+      - name: Build nBallerina sample
+        uses: ballerina-platform/ballerina-action/@nightly
+        with:
+          args:
+            build --dump-build-time --offline ./nballerina/compiler
+
+      - name: Copy nBallerina build-time.json file to build-time-data
+        run: |
+          cp ./nballerina/compiler/target/build-time.json ./build-time-data/nballerina.json
+
+      - name: Build hello_world sample
+        uses: ballerina-platform/ballerina-action/@nightly
+        with:
+          args:
+            build --dump-build-time --offline ./ballerina-distribution/examples/hello-world/hello_world.bal
+
+      - name: Copy hello_world build-time.json file to build-time-data
+        run: |
+          cp build-time.json ./build-time-data/hello_world.json
+
+      - name: Build hello_world_service sample
+        uses: ballerina-platform/ballerina-action/@nightly
+        with:
+          args:
+            build --dump-build-time --offline ./ballerina-distribution/examples/hello-world-service/hello_world_service.bal
+
+      - name: Copy hello_world_service build-time.json file to build-time-data
+        run: |
+          cp build-time.json ./build-time-data/hello_world_service.json
+
+      - name: Push changes to remote
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add build-time-data
+          git commit -m "Update build time stats"
+          git push
+          

--- a/.github/workflows/generate-build-time-stats.yml
+++ b/.github/workflows/generate-build-time-stats.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Push changes to remote
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
+          git config --global user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
 
           git add build-time-data
           git commit -m "Update build time stats"


### PR DESCRIPTION
## Purpose
>  Automate the build time stats generation of samples

## Goals
> PR includes a workflow implementation to automate build-time stats generation for specified samples scheduled basis and push the stats to the build-time-data folder of build-time-data branch

## Approach
> 

- Clone nBallerina, Hello_world, Hello_world_service samples from ballerina-lang repo.
- Set-up Ballerina in the runner.
- Build each project with -dump-build-time
- Remove old stats
- Push back the new stats as bot.
