### PR TITLE
Add script file to handle build process for the generate-build-time-stats workflow

### DIFF
--- a/build-time-data/generate_build_stats.sh
+++ b/build-time-data/generate_build_stats.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright (c) 2022 WSO2 Inc. (http:#www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+examples_list=("nballerina" "hello_world" "hello_world_service")
+
+#Github Folder
+ROOT_DIR=$(pwd)
+
+#Remove old json files and copy new files
+rm -rf $ROOT_DIR/build-time-data/*.json
+
+#Making directories to download examples from remote repo
+mkdir examples
+cd examples
+git clone https://github.com/ballerina-platform/ballerina-distribution.git
+cd ballerina-distribution
+git checkout bbe-refactor
+cd ..
+
+git clone https://github.com/ballerina-platform/nballerina.git
+
+for t in ${examples_list[@]}; do
+  if [[ "$t" == "nballerina" ]]; then
+    cd nballerina/compiler
+    bal build --dump-build-time
+    cp ./target/build-time.json $ROOT_DIR"/build-time-data/nballerina.json"
+    cd $ROOT_DIR/examples
+  else 
+    bal_file=$t".bal"
+    bal_file=$(find $PWD -name $bal_file)
+    cd $ROOT_DIR/build-time-data/
+    bal build --dump-build-time $bal_file
+    rm -rf *.jar
+    mv build-time.json $t".json"
+    cd $ROOT_DIR/examples
+  fi
+
+done

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653613281397,"offline":false,"compile":false,"projectLoadDuration":580,"packageResolutionDuration":1177,"packageCompilationDuration":727,"codeGenDuration":297,"emitArtifactDuration":404,"testingExecutionDuration":0,"totalDuration":3196}
+{"timestamp":1653699614384,"offline":false,"compile":false,"projectLoadDuration":543,"packageResolutionDuration":921,"packageCompilationDuration":538,"codeGenDuration":389,"emitArtifactDuration":397,"testingExecutionDuration":0,"totalDuration":2799}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653959011424,"offline":false,"compile":false,"projectLoadDuration":848,"packageResolutionDuration":1760,"packageCompilationDuration":1211,"codeGenDuration":517,"emitArtifactDuration":570,"testingExecutionDuration":0,"totalDuration":4929}
+{"timestamp":1653981231179,"offline":true,"compile":false,"projectLoadDuration":590,"packageResolutionDuration":203,"packageCompilationDuration":190,"codeGenDuration":273,"emitArtifactDuration":406,"testingExecutionDuration":0,"totalDuration":1683}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,0 +1,1 @@
+{"timestamp":1653571282386,"offline":false,"compile":false,"projectLoadDuration":481,"packageResolutionDuration":969,"packageCompilationDuration":521,"codeGenDuration":266,"emitArtifactDuration":358,"testingExecutionDuration":0,"totalDuration":2610}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653699614384,"offline":false,"compile":false,"projectLoadDuration":543,"packageResolutionDuration":921,"packageCompilationDuration":538,"codeGenDuration":389,"emitArtifactDuration":397,"testingExecutionDuration":0,"totalDuration":2799}
+{"timestamp":1653786328844,"offline":false,"compile":false,"projectLoadDuration":503,"packageResolutionDuration":1320,"packageCompilationDuration":991,"codeGenDuration":317,"emitArtifactDuration":373,"testingExecutionDuration":0,"totalDuration":3512}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653786328844,"offline":false,"compile":false,"projectLoadDuration":503,"packageResolutionDuration":1320,"packageCompilationDuration":991,"codeGenDuration":317,"emitArtifactDuration":373,"testingExecutionDuration":0,"totalDuration":3512}
+{"timestamp":1653872931780,"offline":false,"compile":false,"projectLoadDuration":631,"packageResolutionDuration":987,"packageCompilationDuration":580,"codeGenDuration":320,"emitArtifactDuration":387,"testingExecutionDuration":0,"totalDuration":2920}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653571282386,"offline":false,"compile":false,"projectLoadDuration":481,"packageResolutionDuration":969,"packageCompilationDuration":521,"codeGenDuration":266,"emitArtifactDuration":358,"testingExecutionDuration":0,"totalDuration":2610}
+{"timestamp":1653613281397,"offline":false,"compile":false,"projectLoadDuration":580,"packageResolutionDuration":1177,"packageCompilationDuration":727,"codeGenDuration":297,"emitArtifactDuration":404,"testingExecutionDuration":0,"totalDuration":3196}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653981231179,"offline":true,"compile":false,"projectLoadDuration":590,"packageResolutionDuration":203,"packageCompilationDuration":190,"codeGenDuration":273,"emitArtifactDuration":406,"testingExecutionDuration":0,"totalDuration":1683}
+{"timestamp":1653984138437,"offline":true,"compile":false,"projectLoadDuration":562,"packageResolutionDuration":188,"packageCompilationDuration":199,"codeGenDuration":345,"emitArtifactDuration":419,"testingExecutionDuration":0,"totalDuration":1723}

--- a/build-time-data/hello_world.json
+++ b/build-time-data/hello_world.json
@@ -1,1 +1,1 @@
-{"timestamp":1653872931780,"offline":false,"compile":false,"projectLoadDuration":631,"packageResolutionDuration":987,"packageCompilationDuration":580,"codeGenDuration":320,"emitArtifactDuration":387,"testingExecutionDuration":0,"totalDuration":2920}
+{"timestamp":1653959011424,"offline":false,"compile":false,"projectLoadDuration":848,"packageResolutionDuration":1760,"packageCompilationDuration":1211,"codeGenDuration":517,"emitArtifactDuration":570,"testingExecutionDuration":0,"totalDuration":4929}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653571285859,"offline":false,"compile":false,"projectLoadDuration":510,"packageResolutionDuration":4463,"packageCompilationDuration":4415,"codeGenDuration":418,"emitArtifactDuration":3659,"testingExecutionDuration":0,"totalDuration":13484}
+{"timestamp":1653613285544,"offline":false,"compile":false,"projectLoadDuration":570,"packageResolutionDuration":5365,"packageCompilationDuration":4768,"codeGenDuration":639,"emitArtifactDuration":3649,"testingExecutionDuration":0,"totalDuration":15011}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653981233932,"offline":true,"compile":false,"projectLoadDuration":594,"packageResolutionDuration":584,"packageCompilationDuration":653,"codeGenDuration":370,"emitArtifactDuration":3533,"testingExecutionDuration":0,"totalDuration":5746}
+{"timestamp":1653984141192,"offline":true,"compile":false,"projectLoadDuration":638,"packageResolutionDuration":617,"packageCompilationDuration":625,"codeGenDuration":371,"emitArtifactDuration":3708,"testingExecutionDuration":0,"totalDuration":5969}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653872935667,"offline":false,"compile":false,"projectLoadDuration":597,"packageResolutionDuration":5022,"packageCompilationDuration":4374,"codeGenDuration":567,"emitArtifactDuration":4079,"testingExecutionDuration":0,"totalDuration":14657}
+{"timestamp":1653959017583,"offline":false,"compile":false,"projectLoadDuration":894,"packageResolutionDuration":8144,"packageCompilationDuration":5817,"codeGenDuration":824,"emitArtifactDuration":4446,"testingExecutionDuration":0,"totalDuration":20148}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653699618098,"offline":false,"compile":false,"projectLoadDuration":526,"packageResolutionDuration":5222,"packageCompilationDuration":4536,"codeGenDuration":678,"emitArtifactDuration":3739,"testingExecutionDuration":0,"totalDuration":14721}
+{"timestamp":1653786333291,"offline":false,"compile":false,"projectLoadDuration":510,"packageResolutionDuration":5406,"packageCompilationDuration":5239,"codeGenDuration":476,"emitArtifactDuration":3929,"testingExecutionDuration":0,"totalDuration":15579}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653786333291,"offline":false,"compile":false,"projectLoadDuration":510,"packageResolutionDuration":5406,"packageCompilationDuration":5239,"codeGenDuration":476,"emitArtifactDuration":3929,"testingExecutionDuration":0,"totalDuration":15579}
+{"timestamp":1653872935667,"offline":false,"compile":false,"projectLoadDuration":597,"packageResolutionDuration":5022,"packageCompilationDuration":4374,"codeGenDuration":567,"emitArtifactDuration":4079,"testingExecutionDuration":0,"totalDuration":14657}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,0 +1,1 @@
+{"timestamp":1653571285859,"offline":false,"compile":false,"projectLoadDuration":510,"packageResolutionDuration":4463,"packageCompilationDuration":4415,"codeGenDuration":418,"emitArtifactDuration":3659,"testingExecutionDuration":0,"totalDuration":13484}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653959017583,"offline":false,"compile":false,"projectLoadDuration":894,"packageResolutionDuration":8144,"packageCompilationDuration":5817,"codeGenDuration":824,"emitArtifactDuration":4446,"testingExecutionDuration":0,"totalDuration":20148}
+{"timestamp":1653981233932,"offline":true,"compile":false,"projectLoadDuration":594,"packageResolutionDuration":584,"packageCompilationDuration":653,"codeGenDuration":370,"emitArtifactDuration":3533,"testingExecutionDuration":0,"totalDuration":5746}

--- a/build-time-data/hello_world_service.json
+++ b/build-time-data/hello_world_service.json
@@ -1,1 +1,1 @@
-{"timestamp":1653613285544,"offline":false,"compile":false,"projectLoadDuration":570,"packageResolutionDuration":5365,"packageCompilationDuration":4768,"codeGenDuration":639,"emitArtifactDuration":3649,"testingExecutionDuration":0,"totalDuration":15011}
+{"timestamp":1653699618098,"offline":false,"compile":false,"projectLoadDuration":526,"packageResolutionDuration":5222,"packageCompilationDuration":4536,"codeGenDuration":678,"emitArtifactDuration":3739,"testingExecutionDuration":0,"totalDuration":14721}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653786313814,"offline":false,"compile":false,"projectLoadDuration":568,"packageResolutionDuration":3617,"packageCompilationDuration":4892,"codeGenDuration":4065,"emitArtifactDuration":706,"testingExecutionDuration":0,"totalDuration":13905}
+{"timestamp":1653872917189,"offline":false,"compile":false,"projectLoadDuration":655,"packageResolutionDuration":3380,"packageCompilationDuration":4684,"codeGenDuration":4368,"emitArtifactDuration":546,"testingExecutionDuration":0,"totalDuration":13674}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653981220906,"offline":true,"compile":false,"projectLoadDuration":628,"packageResolutionDuration":1127,"packageCompilationDuration":3091,"codeGenDuration":3747,"emitArtifactDuration":553,"testingExecutionDuration":0,"totalDuration":9182}
+{"timestamp":1653984128288,"offline":true,"compile":false,"projectLoadDuration":675,"packageResolutionDuration":1129,"packageCompilationDuration":2938,"codeGenDuration":3786,"emitArtifactDuration":512,"testingExecutionDuration":0,"totalDuration":9072}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653699601161,"offline":false,"compile":false,"projectLoadDuration":613,"packageResolutionDuration":2992,"packageCompilationDuration":4496,"codeGenDuration":3683,"emitArtifactDuration":554,"testingExecutionDuration":0,"totalDuration":12372}
+{"timestamp":1653786313814,"offline":false,"compile":false,"projectLoadDuration":568,"packageResolutionDuration":3617,"packageCompilationDuration":4892,"codeGenDuration":4065,"emitArtifactDuration":706,"testingExecutionDuration":0,"totalDuration":13905}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,0 +1,1 @@
+{"timestamp":1653571269162,"offline":false,"compile":false,"projectLoadDuration":609,"packageResolutionDuration":2919,"packageCompilationDuration":4173,"codeGenDuration":3960,"emitArtifactDuration":614,"testingExecutionDuration":0,"totalDuration":12314}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653872917189,"offline":false,"compile":false,"projectLoadDuration":655,"packageResolutionDuration":3380,"packageCompilationDuration":4684,"codeGenDuration":4368,"emitArtifactDuration":546,"testingExecutionDuration":0,"totalDuration":13674}
+{"timestamp":1653958989850,"offline":false,"compile":false,"projectLoadDuration":895,"packageResolutionDuration":5381,"packageCompilationDuration":7134,"codeGenDuration":6248,"emitArtifactDuration":653,"testingExecutionDuration":0,"totalDuration":20381}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653571269162,"offline":false,"compile":false,"projectLoadDuration":609,"packageResolutionDuration":2919,"packageCompilationDuration":4173,"codeGenDuration":3960,"emitArtifactDuration":614,"testingExecutionDuration":0,"totalDuration":12314}
+{"timestamp":1653613267600,"offline":false,"compile":false,"projectLoadDuration":644,"packageResolutionDuration":3195,"packageCompilationDuration":4632,"codeGenDuration":3884,"emitArtifactDuration":484,"testingExecutionDuration":0,"totalDuration":12896}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653958989850,"offline":false,"compile":false,"projectLoadDuration":895,"packageResolutionDuration":5381,"packageCompilationDuration":7134,"codeGenDuration":6248,"emitArtifactDuration":653,"testingExecutionDuration":0,"totalDuration":20381}
+{"timestamp":1653981220906,"offline":true,"compile":false,"projectLoadDuration":628,"packageResolutionDuration":1127,"packageCompilationDuration":3091,"codeGenDuration":3747,"emitArtifactDuration":553,"testingExecutionDuration":0,"totalDuration":9182}

--- a/build-time-data/nballerina.json
+++ b/build-time-data/nballerina.json
@@ -1,1 +1,1 @@
-{"timestamp":1653613267600,"offline":false,"compile":false,"projectLoadDuration":644,"packageResolutionDuration":3195,"packageCompilationDuration":4632,"codeGenDuration":3884,"emitArtifactDuration":484,"testingExecutionDuration":0,"totalDuration":12896}
+{"timestamp":1653699601161,"offline":false,"compile":false,"projectLoadDuration":613,"packageResolutionDuration":2992,"packageCompilationDuration":4496,"codeGenDuration":3683,"emitArtifactDuration":554,"testingExecutionDuration":0,"totalDuration":12372}


### PR DESCRIPTION
## Purpose
> Build the Ballerina samples for generate-build-time-stats  work flow.

## Goals
> Script file is responsible for cloning samples, building samples and moving to the build-time-data folder

## Approach
> 
- Clone  samples from remote repo.
- Build inside a folder.
- Remove old stats
- Remove unnecessary files except JSON files
