### PR TITLE
Update swan-lake-2201.2.0-release-note to include JSON to Bal converter changes

### DIFF
--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -696,6 +696,60 @@ digraph "org/package:0.1.0" {
 
 #### Improvements
 
+##### JSON to Record Converter
+Updated the conversion logic to handle certain scenarios more effectively.
+
+###### Handling of array of elements/objects
+Instead of looking at the first object of the array, all elements/objects would be looked at to generate the record field.
+```json
+[
+    { "id": "5001", "type": "None", "index": "15" },
+    { "id": "5002", "type": "Glazed", "index": 15 }
+]
+```
+```ballerina
+type ArrayItem record {
+    string id;
+    string 'type;
+    (int|string) index;
+};
+```
+
+###### Handling optional fields
+If an element is present in a JSON object and not in another(in an array of objects), that field would be treated as optional field.
+```json
+[
+    { "id": "5001", "type": "None", "index": "15" },
+    { "id": "5002", "type": "Glazed"}
+]
+```
+```ballerina
+type ArrayItem record {
+    string id;
+    string 'type;
+    string index?;
+};
+```
+
+###### Handling `null` values
+JSON null fields would be treated as required fields with `anydata` type.
+```json
+{
+  "firstName": "Joe",
+  "lastName": "Jackson",
+  "phoneNumber": null
+}
+```
+```ballerina
+type NewRecord record {
+    string firstName;
+    string lastName;
+    anydata phoneNumber;
+};
+```
+
+Note: The entire JSON value to Ballerina record conversion logic is rewritten to enhance the conversion experience. Above-mentioned scenarios are few noticeable important changes.
+
 ##### Compiler API
 
 - Added semantic API support for the client resource access action

--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -762,15 +762,13 @@ type ArrayItem record {
 JSON `null` fields would be treated as required fields with the `anydata` type.
 ```json
 {
-  "firstName": "Joe",
-  "lastName": "Jackson",
+  "name": "Joe",
   "phoneNumber": null
 }
 ```
 ```ballerina
 type NewRecord record {
-    string firstName;
-    string lastName;
+    string name;
     anydata phoneNumber;
 };
 ```

--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -696,8 +696,8 @@ digraph "org/package:0.1.0" {
 
 #### Improvements
 
-##### JSON to Record Converter
-Updated the conversion logic to handle certain scenarios more effectively.
+##### JSON to record converter
+Improved JSON value to Ballerina record conversion logic.
 
 ###### Handling of array of elements/objects
 Instead of looking at the first object of the array, all elements/objects would be looked at to generate the record field.
@@ -716,7 +716,7 @@ type ArrayItem record {
 ```
 
 ###### Handling optional fields
-If an element is present in a JSON object and not in another(in an array of objects), that field would be treated as optional field.
+If an element is present in a JSON object and not in another (in an array of objects), that field would be treated as an optional field.
 ```json
 [
     { "id": "5001", "type": "None", "index": "15" },
@@ -732,7 +732,7 @@ type ArrayItem record {
 ```
 
 ###### Handling `null` values
-JSON null fields would be treated as required fields with `anydata` type.
+JSON `null` fields would be treated as required fields with the `anydata` type.
 ```json
 {
   "firstName": "Joe",
@@ -748,7 +748,7 @@ type NewRecord record {
 };
 ```
 
-Note: The entire JSON value to Ballerina record conversion logic is rewritten to enhance the conversion experience. Above-mentioned scenarios are few noticeable important changes.
+>**Note:** The entire JSON value to Ballerina record conversion logic is rewritten to enhance the conversion experience. The above-mentioned scenarios are a few noticeable, important changes.
 
 ##### Compiler API
 

--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -629,6 +629,19 @@ To view bug fixes, see the [GitHub milestone for 2201.2.0 (Swan Lake)](https://g
 
 #### New features
 
+##### Language Server
+
+- Added API docs reference support on hover. Now when you hover over a construct (class, type, function), the hover documentation will include a link to view the API docs specific to that construct
+- Added new code actions to extract anonymous records into records and to generate undefined record types
+- Introduced new source actions to generate getters and setters for class-level variables
+- Added a new code action to make annotation declarations with the `source` attach point(s) constant
+- Moved the `Optimize imports` code action to `Source action` and no longer appears under the code action bulb. Source actions are displayed under `Source action` in the context menu
+
+##### OpenAPI Tool
+Added support for generating client resource methods in the client generation command. The preferred client method type can be chosen using the `--client-methods=<remote(default)|resource>` option.
+- `$ bal openapi -i <OpenAPI contract> --client-methods=resource`
+- `$ bal openapi -i <OpenAPI contract> --mode client --client-methods=resource`
+
 ##### SemVer validator CLI tool (Experimental)
 Introduced the `bal semver` CLI command, which attempts to validate <a href="https://semver.org/">Semantic Versioning</a> compatibility of the local package changes against any previously published version(s) in Ballerina Central. Currently, the tool can be used to: 
 - list down the source code differences (along with its compatibility impact) between the local and any published versions in Ballerina central
@@ -696,6 +709,22 @@ digraph "org/package:0.1.0" {
 
 #### Improvements
 
+##### Language Server
+- Improved the `Create variable` code action in the `async send` action
+- Added completion support for the resource access action context
+
+##### OpenAPI Tool
+Added support for OpenAPI schema constraint properties in client/service generation. With this improvement, the OpenAPI constraints will be applied as `ballerina/constraint` standard library package annotations when generating Ballerina clients and services from the OpenAPI definition.
+The following OpenAPI properties are currently supported in the Ballerina OpenAPI generation tool.
+- `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` for `integer` and `number` types
+- `minLength` and `maxLength` for `string` type
+- `minItems` and `maxItems` for `array` type
+
+To view bug fixes, see the GitHub milestone for 2201.2.0 (Swan Lake) of the repositories below.
+
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3ATeam%2FLanguageServer)
+- [update tool](https://github.com/ballerina-platform/ballerina-update-tool/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3AType%2FBug)
+
 ##### JSON to record converter
 Improved JSON value to Ballerina record conversion logic.
 
@@ -761,42 +790,6 @@ type NewRecord record {
 #### Bug fixes
 
 ### Breaking changes
-
-### Developer tools updates
-
-#### New features
-
-##### Language Server
-
-- Added API docs reference support on hover. Now when you hover over a construct (class, type, function), the hover documentation will include a link to view the API docs specific to that construct
-- Added new code actions to extract anonymous records into records and to generate undefined record types
-- Introduced new source actions to generate getters and setters for class-level variables
-- Added a new code action to make annotation declarations with the `source` attach point(s) constant
-- Moved the `Optimize imports` code action to `Source action` and no longer appears under the code action bulb. Source actions are displayed under `Source action` in the context menu
-
-##### OpenAPI Tool
-Added support for generating client resource methods in the client generation command. The preferred client method type can be chosen using the `--client-methods=<remote(default)|resource>` option.
-  - `$ bal openapi -i <OpenAPI contract> --client-methods=resource`
-  - `$ bal openapi -i <OpenAPI contract> --mode client --client-methods=resource`
-
-#### Improvements
-
-##### Language Server
-- Improved the `Create variable` code action in the `async send` action
-- Added completion support for the resource access action context
-
-##### OpenAPI Tool
-Added support for OpenAPI schema constraint properties in client/service generation. With this improvement, the OpenAPI constraints will be applied as `ballerina/constraint` standard library package annotations when generating Ballerina clients and services from the OpenAPI definition.
-The following OpenAPI properties are currently supported in the Ballerina OpenAPI generation tool. 
-- `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum` for `integer` and `number` types
-- `minLength` and `maxLength` for `string` type
-- `minItems` and `maxItems` for `array` type
-
-To view bug fixes, see the GitHub milestone for 2201.2.0 (Swan Lake) of the repositories below.
-
-- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3ATeam%2FLanguageServer)
-- [update tool](https://github.com/ballerina-platform/ballerina-update-tool/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3AType%2FBug)
-
 
 ### Ballerina packages updates
 

--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -726,7 +726,7 @@ To view bug fixes, see the GitHub milestone for 2201.2.0 (Swan Lake) of the repo
 - [update tool](https://github.com/ballerina-platform/ballerina-update-tool/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3AType%2FBug)
 
 ##### JSON to record converter
-Improved JSON value to Ballerina record conversion logic, to enhance the conversion experience in `Paste JSON as a record` feature in Ballerina VSCode extension.
+Improved JSON value to Ballerina record conversion logic, to enhance the conversion experience of `Paste JSON as record` feature in Ballerina VSCode extension.
 
 ###### Handling of array of elements/objects
 Instead of looking at the first object of the array, all elements/objects would be looked at to generate the record field.

--- a/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.2.0-release-note.md
@@ -726,20 +726,19 @@ To view bug fixes, see the GitHub milestone for 2201.2.0 (Swan Lake) of the repo
 - [update tool](https://github.com/ballerina-platform/ballerina-update-tool/issues?q=is%3Aissue+milestone%3A%22Ballerina+2201.2.0%22+is%3Aclosed+label%3AType%2FBug)
 
 ##### JSON to record converter
-Improved JSON value to Ballerina record conversion logic.
+Improved JSON value to Ballerina record conversion logic, to enhance the conversion experience in `Paste JSON as a record` feature in Ballerina VSCode extension.
 
 ###### Handling of array of elements/objects
 Instead of looking at the first object of the array, all elements/objects would be looked at to generate the record field.
 ```json
 [
-    { "id": "5001", "type": "None", "index": "15" },
-    { "id": "5002", "type": "Glazed", "index": 15 }
+    { "id": "5001", "index": "15" },
+    { "id": "5002", "index": 16 }
 ]
 ```
 ```ballerina
 type ArrayItem record {
     string id;
-    string 'type;
     (int|string) index;
 };
 ```
@@ -748,14 +747,13 @@ type ArrayItem record {
 If an element is present in a JSON object and not in another (in an array of objects), that field would be treated as an optional field.
 ```json
 [
-    { "id": "5001", "type": "None", "index": "15" },
-    { "id": "5002", "type": "Glazed"}
+    { "id": "5001", "index": "15" },
+    { "id": "5002" }
 ]
 ```
 ```ballerina
 type ArrayItem record {
     string id;
-    string 'type;
     string index?;
 };
 ```


### PR DESCRIPTION
## Purpose
> This PR contains the release-note updates on JSON to Ballerina record converter tool changes.