### PR TITLE
Select downstream repo branch in full build pipeline

### DIFF
--- a/.github/workflows/daily-full-build-master.yml
+++ b/.github/workflows/daily-full-build-master.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build Modules
         run: |
-          python dependabot/build_stdlibs_for_lang_updates.py master true ballerina-platform
+          python dependabot/build_stdlibs_for_lang_updates.py master true ballerina-platform master
         env:
           BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
           BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/.github/workflows/full_build_pipeline.yml
+++ b/.github/workflows/full_build_pipeline.yml
@@ -7,6 +7,10 @@ on:
           description: 'Ballerina-lang branch'
           required: true
           default: 'master'
+        downstream_repo_branch:
+          description: 'Downstream repository branch'
+          required: true
+          default: 'master'
         enable_tests:
           type: choice
           description: 'Enable Tests'
@@ -35,7 +39,8 @@ jobs:
           pip install PyGithub
       - name: Build Modules
         run: |
-          python dependabot/build_stdlibs_for_lang_updates.py ${{ github.event.inputs.ballerina_lang_branch }} ${{ github.event.inputs.enable_tests }} ${{ github.repository_owner }}
+          python dependabot/build_stdlibs_for_lang_updates.py ${{ github.event.inputs.ballerina_lang_branch }} \
+          ${{ github.event.inputs.enable_tests }} ${{ github.repository_owner }} ${{ github.event.inputs.downstream_repo_branch }}
         env:
           BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
           BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/dependabot/build_stdlibs_for_lang_updates.py
+++ b/dependabot/build_stdlibs_for_lang_updates.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 
+DEFAULT_DOWNSTREAM_REPO_BRANCH = "master"
 
 stdlib_modules_by_level = dict()
 test_ignore_modules = []
@@ -14,6 +15,7 @@ stdlib_modules_json_file = 'https://raw.githubusercontent.com/ballerina-platform
 test_ignore_modules_file = 'dependabot/resources/full_build_ignore_modules.json'
 
 ballerina_lang_branch = "master"
+downstream_repo_branch = "master"
 enable_tests = 'true'
 github_user = 'ballerina-platform'
 exit_code = 0
@@ -29,6 +31,7 @@ def main():
     global test_ignore_modules
     global build_ignore_modules
     global ballerina_lang_branch
+    global downstream_repo_branch
     global github_user
     global enable_tests
 
@@ -36,6 +39,7 @@ def main():
         ballerina_lang_branch = sys.argv[1]
         enable_tests = sys.argv[2]
         github_user = sys.argv[3]
+        downstream_repo_branch = sys.argv[4]
 
     read_stdlib_modules()
     read_ignore_modules()
@@ -117,6 +121,12 @@ def clone_repositories():
             exit_code = os.system(f"git clone {constants.BALLERINA_ORG_URL}{module['name']}.git")
             if exit_code != 0:
                 sys.exit(1)
+
+            if downstream_repo_branch != DEFAULT_DOWNSTREAM_REPO_BRANCH:
+                exit_code = os.system(f"cd {module['name']};git checkout {downstream_repo_branch}")
+                os.system(f"cd {module['name']};git status")
+                if exit_code != 0:
+                    sys.exit(1)
 
     # Clone ballerina-distribution repo
     exit_code = os.system(f"git clone {constants.BALLERINA_ORG_URL}ballerina-distribution.git")

--- a/dependabot/build_stdlibs_for_lang_updates.py
+++ b/dependabot/build_stdlibs_for_lang_updates.py
@@ -5,7 +5,6 @@ import os
 import sys
 from pathlib import Path
 
-DEFAULT_DOWNSTREAM_REPO_BRANCH = "master"
 
 stdlib_modules_by_level = dict()
 test_ignore_modules = []
@@ -122,11 +121,8 @@ def clone_repositories():
             if exit_code != 0:
                 sys.exit(1)
 
-            if downstream_repo_branch != DEFAULT_DOWNSTREAM_REPO_BRANCH:
-                exit_code = os.system(f"cd {module['name']};git checkout {downstream_repo_branch}")
-                os.system(f"cd {module['name']};git status")
-                if exit_code != 0:
-                    sys.exit(1)
+            os.system(f"cd {module['name']};git checkout {downstream_repo_branch}")
+            os.system(f"cd {module['name']};git status")
 
     # Clone ballerina-distribution repo
     exit_code = os.system(f"git clone {constants.BALLERINA_ORG_URL}ballerina-distribution.git")


### PR DESCRIPTION
## Purpose
This will enable the option to select downstream repository branch (assuming all the standard library have a unique branch) when triggering the workflow in https://github.com/ballerina-platform/ballerina-release/actions/workflows/full_build_pipeline.yml

## Goals
To test new features with the full build pipeline.

Fixes #2128 