### PR TITLE
Remove Packages section from Update 3 release note

### DIFF
--- a/release-notes/swan-lake-release-notes/swan-lake-2201.3.0-release-note.md
+++ b/release-notes/swan-lake-release-notes/swan-lake-2201.3.0-release-note.md
@@ -108,13 +108,4 @@ To view bug fixes, see the GitHub milestone for 2201.3.0 (Swan Lake) of the repo
 - [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+label%3AType%2FBug+milestone%3A%22Ballerina+2201.3.0%22+is%3Aclosed)
 - [ProjectAPI](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FDevTools+milestone%3A2201.3.0+label%3AArea%2FProjectAPI)
 
-
-## Package updates
-
-### New features
-
-### Improvements
-
-### Bug fixes
-
 ## Breaking changes


### PR DESCRIPTION
## Purpose
> Remove Packages section from Update 3 release note 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no
