### PR TITLE
Include downstream repo branch as a config

### DIFF
--- a/.github/workflows/daily-full-build-2201.3.x.yml
+++ b/.github/workflows/daily-full-build-2201.3.x.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build Modules
         run: |
-          python dependabot/build_stdlibs_for_lang_updates.py 2201.3.x true ballerina-platform master
+          python dependabot/full_build_pipeline_for_updated_stages.py 2201.3.x true ballerina-platform 2201.3.x
         env:
           BALLERINA_BOT_USERNAME: ${{ secrets.BALLERINA_BOT_USERNAME }}
           BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/dependabot/resources/full_build_ignore_modules.json
+++ b/dependabot/resources/full_build_ignore_modules.json
@@ -1,22 +1,21 @@
 {
   "master": {
     "test-ignore-modules": [],
-    "build-ignore-modules": []
-  },
-  "2201.0.x": {
-    "test-ignore-modules": ["module-ballerina-c2c", "module-ballerina-http"],
-    "build-ignore-modules": ["module-ballerina-constraint", "module-ballerina-serdes", "module-ballerina-persist"]
-  },
-  "2201.1.x": {
-    "test-ignore-modules": [],
-    "build-ignore-modules": ["module-ballerina-constraint", "module-ballerina-serdes", "module-ballerina-persist"]
+    "build-ignore-modules": [],
+    "downstream-repo-branches": {}
   },
   "2201.2.x": {
     "test-ignore-modules": [],
-    "build-ignore-modules": ["module-ballerina-persist"]
+    "build-ignore-modules": ["module-ballerina-persist"],
+    "downstream-repo-branches": {
+      "module-ballerina-c2c": "2201.2.x"
+    }
   },
   "2201.3.x": {
     "test-ignore-modules": [],
-    "build-ignore-modules": []
+    "build-ignore-modules": [],
+    "downstream-repo-branches": {
+      "module-ballerina-c2c": "2201.3.x"
+    }
   }
 }


### PR DESCRIPTION
## Purpose
This PR will include downstream repository branch as a config for each module if it is needed to be specified in https://github.com/ballerina-platform/ballerina-release/blob/master/dependabot/resources/full_build_ignore_modules.json.

The structure of full_build_ignore_modules.json will be as follows.

```json
{
  "master": {
    "test-ignore-modules": [],
    "build-ignore-modules": [],
    "downstream-repo-branches": {}
  },
  "patch_branch_level1": {
    "test-ignore-modules": ["module_name1"],
    "build-ignore-modules": ["module_name1"],
    "downstream-repo-branches": {
      "module_name1": "branch_name1"
    }
  },
  "patch_branch_level2": {
    "test-ignore-modules": ["module_name1"],
    "build-ignore-modules": ["module_name1"],
    "downstream-repo-branches": {
      "module_name1": "branch_name1"
    }
  }
}
```

### Fixes #2219 
