### PR TITLE
Skip debugger integration tests in ballerina-lang in FBP

### DIFF
--- a/dependabot/full_build_pipeline.py
+++ b/dependabot/full_build_pipeline.py
@@ -165,6 +165,11 @@ def main():
         print_info(f"Lang version: {lang_version}")
         lang_build_commands = ["./gradlew", "clean", "build", "--scan", "--stacktrace", "--console=plain",
                                "--no-daemon", "publishToMavenLocal"]
+
+        # Temporary
+        lang_build_commands.append("-x")
+        lang_build_commands.append(":jballerina-debugger-integration-test:test")
+
         if skip_tests:
             lang_build_commands.append("-x")
             lang_build_commands.append("test")


### PR DESCRIPTION
## Purpose
debugger-integration tests are failing intermittently in FBP and this will skip the tests temporary.

### Issue #2376 