### PR TITLE
Ignore math.vector module in ballerina 2201.3.x distribution

### DIFF
--- a/dependabot/resources/full_build_ignore_modules.json
+++ b/dependabot/resources/full_build_ignore_modules.json
@@ -37,7 +37,8 @@
       "persist-tools",
       "ballerina-dev-tools",
       "module-ballerina-toml",
-      "module-ballerina-yaml"
+      "module-ballerina-yaml",
+      "module-ballerina-math.vector"
     ],
     "downstream-repo-branches": {
       "module-ballerina-c2c": "2201.3.x",


### PR DESCRIPTION
## Purpose
Ignore math.vector module in ballerina 2201.3.x distribution

Fixes: https://github.com/wso2-enterprise/choreo/issues/21394