### PR TITLE
Remove persist.googlesheets from the modulelist.json

### DIFF
--- a/dependabot/resources/module_list.json
+++ b/dependabot/resources/module_list.json
@@ -270,10 +270,6 @@
             "name": "module-ballerina-constraint"
         },
         {
-            "name": "module-ballerinax-persist.googlesheets",
-            "version_key": "stdlibPersistGoogleSheetVersion"
-        },
-        {
             "name": "module-ballerinax-persist.inmemory",
             "version_key": "stdlibPersistInmemoryVersion"
         },


### PR DESCRIPTION
## Purpose
$subject

This is done in order to fix the PR workflow failures happen due to the addition of `module-ballerinax-persist.googlesheets` repository.