### PR TITLE
Fix nBallerina build failures

### DIFF
--- a/.github/workflows/daily-full-build-2201.3.x.yml
+++ b/.github/workflows/daily-full-build-2201.3.x.yml
@@ -428,6 +428,9 @@ jobs:
           pip install httplib2
       - name: Clone nBallerina repository
         run: git clone https://github.com/ballerina-platform/nballerina.git
+      - name: Switch to last working nBallerina commit
+        run: git checkout jballerina-2201.3
+        working-directory: nballerina
       - name: Download Linux Deb Installer
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/daily-full-build-2201.4.x.yml
+++ b/.github/workflows/daily-full-build-2201.4.x.yml
@@ -428,6 +428,9 @@ jobs:
           pip install httplib2
       - name: Clone nBallerina repository
         run: git clone https://github.com/ballerina-platform/nballerina.git
+      - name: Switch to last working nBallerina commit
+        run: git checkout jballerina-2201.4
+        working-directory: nballerina
       - name: Download Linux Deb Installer
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/daily-full-build-2201.5.x.yml
+++ b/.github/workflows/daily-full-build-2201.5.x.yml
@@ -464,6 +464,9 @@ jobs:
           pip install httplib2
       - name: Clone nBallerina repository
         run: git clone https://github.com/ballerina-platform/nballerina.git
+      - name: Switch to last working nBallerina commit
+        run: git checkout jballerina-2201.5
+        working-directory: nballerina
       - name: Download Linux Deb Installer
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/daily-full-build-2201.6.x.yml
+++ b/.github/workflows/daily-full-build-2201.6.x.yml
@@ -467,6 +467,9 @@ jobs:
           pip install httplib2
       - name: Clone nBallerina repository
         run: git clone https://github.com/ballerina-platform/nballerina.git
+      - name: Switch to last working nBallerina commit
+        run: git checkout jballerina-2201.6
+        working-directory: nballerina
       - name: Download Linux Deb Installer
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
## Purpose
When nBallerina updates its jBallerina dependencies it potentially makes itself unusable as a test target for older versions of jBallerina. Therefore moving forward nBallerina will tag the last commit it has tested to work with a given major version of jBallerina before updating.