### PR TITLE
Update trigger time of the ballerinax connectors full build workflow

### DIFF
--- a/.github/workflows/trigger-ballerinax-connectors-build.yml
+++ b/.github/workflows/trigger-ballerinax-connectors-build.yml
@@ -3,7 +3,7 @@ name: Trigger ballerinax connectors build
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 18 * * *'   # 00:00 in LK time (GMT+5:30)
+    - cron: '30 19 * * *'   # 01:00AM IST (GMT+5:30) 
 
 jobs:
   get_connector_list:


### PR DESCRIPTION
## Purpose
$subject to avoid having conflicts with the graalVM builds, which were getting triggered at the same time.
