### PR TITLE
Update the deprecated artifact action version to v4

### DIFF
--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./gradlew codeCoverageReport --stacktrace -scan --console=plain --no-daemon
 
       - name: Archive Code Coverage Zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: CoverageReport
           path: coverage-reports/build/reports/jacoco/codeCoverageReport

--- a/.github/workflows/daily-full-build-2201.10.x.yml
+++ b/.github/workflows/daily-full-build-2201.10.x.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -192,27 +192,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -225,12 +225,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -342,7 +342,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -388,7 +388,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -428,7 +428,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.3.x.yml
+++ b/.github/workflows/daily-full-build-2201.3.x.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -182,22 +182,22 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -210,12 +210,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -327,7 +327,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -382,7 +382,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.4.x.yml
+++ b/.github/workflows/daily-full-build-2201.4.x.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -182,22 +182,22 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -210,12 +210,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -327,7 +327,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -382,7 +382,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.5.x.yml
+++ b/.github/workflows/daily-full-build-2201.5.x.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -182,27 +182,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -215,12 +215,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -332,7 +332,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -378,7 +378,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -418,7 +418,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.6.x.yml
+++ b/.github/workflows/daily-full-build-2201.6.x.yml
@@ -64,7 +64,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -184,27 +184,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -217,12 +217,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -334,7 +334,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -380,7 +380,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -420,7 +420,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.7.x.yml
+++ b/.github/workflows/daily-full-build-2201.7.x.yml
@@ -64,7 +64,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -192,27 +192,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -225,12 +225,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -342,7 +342,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -388,7 +388,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -428,7 +428,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.8.x.yml
+++ b/.github/workflows/daily-full-build-2201.8.x.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -192,27 +192,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -225,12 +225,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -342,7 +342,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -388,7 +388,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -428,7 +428,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-2201.9.x.yml
+++ b/.github/workflows/daily-full-build-2201.9.x.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -192,27 +192,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -225,12 +225,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -342,7 +342,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -388,7 +388,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -428,7 +428,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/daily-full-build-master.yml
+++ b/.github/workflows/daily-full-build-master.yml
@@ -72,7 +72,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -127,7 +127,7 @@ jobs:
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           TEST_MODE_ACTIVE: true
       - name: Archive Standard Library Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Standard Library Artifacts
           path: ~/.m2/
@@ -202,27 +202,27 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive MacOS-ARM Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-ARM Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos-arm.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -235,12 +235,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -352,7 +352,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -398,7 +398,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../ -a arm
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-arm-x64.pkg
@@ -438,7 +438,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/full_build_pipeline.yml
+++ b/.github/workflows/full_build_pipeline.yml
@@ -140,7 +140,7 @@ jobs:
           echo "::set-output name=version::$VERSION"
           echo "::set-output name=specVersion::$SPEC_VERSION"
       - name: Archive Lang Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Lang Artifacts
           path: ~/.m2/
@@ -239,7 +239,7 @@ jobs:
           TEST_MODE_ACTIVE: true
           CENTRAL_VERBOSE_ENABLED: true
       - name: Archive Standard Library Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Standard Library Artifacts
           path: ~/.m2/
@@ -340,22 +340,22 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sVersion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -368,12 +368,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -484,7 +484,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-distribution.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -546,7 +546,7 @@ jobs:
           cd w
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-distribution.outputs.project-version }} --path .\..\
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi

--- a/.github/workflows/full_build_pipeline_for_updated_stages.yml
+++ b/.github/workflows/full_build_pipeline_for_updated_stages.yml
@@ -77,22 +77,22 @@ jobs:
           echo "::set-output name=version::$RELEASE_VERSION"
           echo "::set-output name=sversion::$SHORT_VERSION"
       - name: Archive Ballerina ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-swan-lake.zip
       - name: Archive Ballerina Short Name ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Ballerina Short Name ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-22*.zip
       - name: Archive MacOS Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-macos.zip
       - name: Archive Windows Installer ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer ZIP
           path: ballerina-distribution/ballerina/build/distributions/ballerina-*-windows.zip
@@ -105,12 +105,12 @@ jobs:
         working-directory: ballerina-distribution/installers/linux-rpm
         run: ./build-ballerina-linux-rpm-x64.sh -v ${{ steps.project-version.outputs.version }} -p ./../../ballerina/build/distributions
       - name: Archive Linux deb
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer deb
           path: ballerina-distribution/installers/linux-deb/target/ballerina-*-linux-x64.deb
       - name: Archive Linux rpm
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Linux Installer rpm
           path: ballerina-distribution/installers/linux-rpm/rpmbuild/RPMS/x86_64/ballerina-*-linux-x64.rpm
@@ -140,7 +140,7 @@ jobs:
         working-directory: ballerina-distribution/installers/mac
         run: ./build-ballerina-macos-x64.sh -v ${{ needs.build-pipeline.outputs.project-version }} -p ./../../../
       - name: Archive MacOS pkg
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS Installer pkg
           path: ballerina-distribution/installers/mac/target/pkg/ballerina-*-macos-x64.pkg
@@ -174,7 +174,7 @@ jobs:
           .\build-ballerina-windows-x64.bat --version ${{ needs.build-pipeline.outputs.project-version }} --path .\..\
           echo "Created windows-msi successfully"
       - name: Archive Windows msi
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Windows Installer msi
           path: w\target\msi\ballerina-*-windows-x64.msi


### PR DESCRIPTION
## Purpose
GitHub has deprecated the artifact action v1 and v2 which leads to build failures in release workflows.
https://github.com/ballerina-platform/ballerina-release/actions/runs/10826921877/job/30038931866

**Deprecation notice:**  https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions
