### PR TITLE
Revert bot changes for tools in extensions.json 

### DIFF
--- a/dependabot/resources/extensions.json
+++ b/dependabot/resources/extensions.json
@@ -432,7 +432,7 @@
             "build_action_file": "build-timestamped-master",
             "send_notification": true,
             "dependents": [
-                "persist-tools"
+                "persist-tool"
             ]
         },
         {
@@ -756,7 +756,7 @@
                 "module-ballerinax-azure.functions",
                 "module-ballerina-c2c",
                 "module-ballerinax-choreo",
-                "openapi-tools",
+                "openapi-tool",
                 "ballerina-dev-tools"
             ]
         },
@@ -808,7 +808,7 @@
             "send_notification": true,
             "dependents": [
                 "module-ballerina-graphql",
-                "asyncapi-tools"
+                "asyncapi-tool"
             ]
         },
         {
@@ -827,7 +827,7 @@
                 "module-ballerinax-aws.lambda",
                 "module-ballerinax-azure.functions",
                 "module-ballerina-c2c",
-                "openapi-tools"
+                "openapi-tool"
             ]
         },
         {
@@ -880,8 +880,8 @@
                 "module-ballerinax-aws.lambda",
                 "module-ballerinax-azure.functions",
                 "module-ballerina-c2c",
-                "graphql-tools",
-                "openapi-tools",
+                "graphql-tool",
+                "openapi-tool",
                 "ballerina-dev-tools"
             ]
         },
@@ -1003,14 +1003,14 @@
             ]
         },
         {
-            "name": "graphql-tools",
+            "name": "graphql-tool",
             "level": 10,
             "group_id": "io.ballerina",
-            "artifact_id": "graphql-tools",
+            "artifact_id": "graphql-tool",
             "version_key": "graphqlToolVersion",
             "default_branch": "main",
             "auto_merge": true,
-            "push_to_central": false,
+            "push_to_central": true,
             "is_extended_library_module": false,
             "build_action_file": "build-timestamped-master",
             "send_notification": true,
@@ -1019,10 +1019,26 @@
             ]
         },
         {
-            "name": "openapi-tools",
+            "name": "protoc-tool",
             "level": 10,
             "group_id": "io.ballerina",
-            "artifact_id": "module-ballerina-openapi",
+            "artifact_id": "protoc-tool",
+            "version_key": "protocToolVersion",
+            "default_branch": "main",
+            "auto_merge": true,
+            "push_to_central": true,
+            "is_extended_library_module": false,
+            "build_action_file": "build-timestamped-master",
+            "send_notification": true,
+            "dependents": [
+                "ballerina-distribution"
+            ]
+        },
+        {
+            "name": "openapi-tool",
+            "level": 10,
+            "group_id": "io.ballerina",
+            "artifact_id": "openapi-tool",
             "version_key": "openapiToolVersion",
             "default_branch": "master",
             "auto_merge": true,
@@ -1035,10 +1051,10 @@
             ]
         },
         {
-            "name": "asyncapi-tools",
+            "name": "asyncapi-tool",
             "level": 10,
             "group_id": "io.ballerina",
-            "artifact_id": "module-ballerina-asyncapi",
+            "artifact_id": "asyncapi-tool",
             "version_key": "asyncapiToolVersion",
             "default_branch": "main",
             "auto_merge": true,
@@ -1063,14 +1079,14 @@
             "build_action_file": "build-timestamped-master",
             "send_notification": true,
             "dependents": [
-                "persist-tools"
+                "persist-tool"
             ]
         },
         {
-            "name": "persist-tools",
+            "name": "persist-tool",
             "level": 12,
             "group_id": "io.ballerina",
-            "artifact_id": "persist-tools",
+            "artifact_id": "persist-tool",
             "version_key": "persistToolVersion",
             "default_branch": "main",
             "auto_merge": true,


### PR DESCRIPTION
## Purpose
> Revert bot changes for tools on extensions.json 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request reverts automated changes that were made to the extension tools configuration. The revert operation restores the extension definitions in `dependabot/resources/extensions.json` by:

- Updating extension naming conventions across tool references (`persist-tools` → `persist-tool`, `openapi-tools` → `openapi-tool`, `asyncapi-tools` → `asyncapi-tool`, `graphql-tools` → `graphql-tool`)
- Adjusting configuration settings for extension entries, including push-to-central flags and build action metadata
- Introducing a new extension entry for `protoc-tool`
- Updating dependency relationships to align with the revised extension naming structure

The changes affect 32 lines with 16 lines removed, restoring the extensions configuration to a known stable state following a series of automated tool updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->