### PR TITLE
Add mcp to module list

### DIFF
--- a/dependabot/resources/module_list.json
+++ b/dependabot/resources/module_list.json
@@ -155,6 +155,10 @@
             "version_key": "stdlibMathVectorVersion"
         },
         {
+            "name": "module-ballerina-mcp",
+            "is_extended_library_module": false
+        },
+        {
             "name": "module-ballerina-mime"
         },
         {


### PR DESCRIPTION
## Purpose
$title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added `module-ballerina-mcp` to the standard library module list. The module is not marked as an extended library module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->